### PR TITLE
[Conflict] Track the source of every conflicting requirement

### DIFF
--- a/lib/resolver/errors.rb
+++ b/lib/resolver/errors.rb
@@ -27,8 +27,17 @@ module Resolver
 
     # @param [{String => Resolution::Conflict}] conflicts see {#conflicts}
     def initialize(conflicts)
+      pairs = []
+      conflicts.values.flatten.map(&:requirements).flatten.each do |conflicting|
+        conflicting.each do |source, conflict_requirements|
+          conflict_requirements.each do |c|
+            pairs << [c, source]
+          end
+        end
+      end
+
       super "Unable to satisfy the following requirements:\n\n" \
-        "#{conflicts.values.flatten.map(&:requirements).flatten.map { |r| "- `#{r}`" }.join("\n")}"
+        "#{pairs.map { |r, d| "- `#{r}` required by `#{d}`" }.join("\n")}"
       @conflicts = conflicts
     end
   end

--- a/lib/resolver/modules/specification_provider.rb
+++ b/lib/resolver/modules/specification_provider.rb
@@ -16,6 +16,10 @@ module Resolver
       dependency.inspect
     end
 
+    def name_for_explicit_dependency_source
+      'user-specified dependency'
+    end
+
     # Sort dependencies so that the ones that are easiest to resolve are first.
     # Easiest to resolve is (usually) defined by:
     #   1) Is this dependency already activated?

--- a/spec/dependency_graph_spec.rb
+++ b/spec/dependency_graph_spec.rb
@@ -8,7 +8,7 @@ module Resolver
         @graph = DependencyGraph.new
         @root  = @graph.add_root_vertex('Root', 'Root')
         @root2 = @graph.add_root_vertex('Root2', 'Root2')
-        @child = @graph.add_child_vertex('Child', 'Child', %w(Root))
+        @child = @graph.add_child_vertex('Child', 'Child', %w(Root), 'Child')
       end
 
       it 'returns root vertices by name' do
@@ -50,7 +50,7 @@ module Resolver
 
       it 'detaches a root vertex with successors' do
         root = @graph.add_root_vertex('root', 'root')
-        child = @graph.add_child_vertex('child', 'child', %w(root))
+        child = @graph.add_child_vertex('child', 'child', %w(root), 'child')
         @graph.detach_vertex_named(root.name)
         @graph.vertex_named(root.name).
           should.equal nil
@@ -63,7 +63,7 @@ module Resolver
       it 'detaches a root vertex with successors with other parents' do
         root = @graph.add_root_vertex('root', 'root')
         root2 = @graph.add_root_vertex('root2', 'root2')
-        child = @graph.add_child_vertex('child', 'child', %w(root root2))
+        child = @graph.add_child_vertex('child', 'child', %w(root root2), 'child')
         @graph.detach_vertex_named(root.name)
         @graph.vertex_named(root.name).
           should.equal nil

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -29,7 +29,7 @@ module Resolver
             dependency = index.specs[name].find { |s| s.version == version }
             node = if parent
                      graph.add_vertex(name, dependency).tap do |v|
-                       graph.add_edge(parent, v)
+                       graph.add_edge(parent, v, dependency)
                      end
                    else
                      graph.add_root_vertex(name, dependency)


### PR DESCRIPTION
Before I merge this, I want to make sure this seems sane?
It enables the following output (the `required by` part) in CocoaPods:

```
[!] Unable to satisfy the following requirements:

- `AFNetworking (~> 1.3.0)` required by `RestKit/Network (0.23.1)`
- `AFNetworking (> 2)` required by `Podfile`
- `RestKit/Network` required by `RestKit/Core (0.23.1)`
- `RestKit/CoreData` required by `RestKit/Core (0.23.1)`
- `RestKit/Core` required by `RestKit (0.23.1)`
```

\c @alloy, @floere
