### PR TITLE
[UI] Print debug output to stdout

### DIFF
--- a/lib/molinillo/modules/ui.rb
+++ b/lib/molinillo/modules/ui.rb
@@ -40,7 +40,6 @@ module Molinillo
     end
 
     # Conveys debug information to the user.
-    # By default, prints to `STDERR` instead of {#output}.
     #
     # @param [Integer] depth the current depth of the resolution process.
     # @return [void]
@@ -48,7 +47,7 @@ module Molinillo
       if debug?
         debug_info = yield
         debug_info = debug_info.inspect unless debug_info.is_a?(String)
-        STDERR.puts debug_info.split("\n").map { |s| '  ' * depth + s }
+        puts debug_info.split("\n").map { |s| '  ' * depth + s }
       end
     end
 


### PR DESCRIPTION
I don't think it makes sense for debug information to go to stderr as it is not and error. Also causing strange behaviours in CocoaPods integration tests when stderr and stdout is merged inconsistently.
