### PR TITLE
[Resolution] Make it warning-clean

### DIFF
--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -73,6 +73,19 @@ module Molinillo
         end_resolution
       end
 
+      # @return [Integer] the number of resolver iterations in between calls to
+      #   {#resolver_ui}'s {UI#indicate_progress} method
+      attr_accessor :iteration_rate
+      private :iteration_rate
+
+      # @return [Time] the time at which resolution began
+      attr_accessor :started_at
+      private :started_at
+
+      # @return [Array<ResolutionState>] the stack of states for the resolution
+      attr_accessor :states
+      private :states
+
       private
 
       # Sets up the resolution process
@@ -100,16 +113,6 @@ module Molinillo
 
       require 'molinillo/state'
       require 'molinillo/modules/specification_provider'
-
-      # @return [Integer] the number of resolver iterations in between calls to
-      #   {#resolver_ui}'s {UI#indicate_progress} method
-      attr_accessor :iteration_rate
-
-      # @return [Time] the time at which resolution began
-      attr_accessor :started_at
-
-      # @return [Array<ResolutionState>] the stack of states for the resolution
-      attr_accessor :states
 
       ResolutionState.new.members.each do |member|
         define_method member do |*args, &block|


### PR DESCRIPTION
This makes `Resolution` warning-clean, which, in turn, would make Bundler warning-clean again.

This particular Ruby warning (`private attribute?`) is questionable (to say the least) and the fix is awful, but being warning-clean means all of the programs and libraries that depend on Molinillo can be warning-clean.