### PR TITLE
Remove transitive requirements when swapping children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Recursively prune requirements when removing an orphan after swapping.  
+  [Daniel DeLeo](https://github.com/danielsdeleo)
+  [berkshelf/solve#57](https://github.com/berkshelf/solve/issues/57)
 
 
 ## 0.4.4 (2016-02-28)

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -363,7 +363,13 @@ module Molinillo
           if !dep_names.include?(succ.name) && !succ.root? && succ.predecessors.to_a == [vertex]
             debug(depth) { "Removing orphaned spec #{succ.name} after swapping #{name}" }
             activated.detach_vertex_named(succ.name)
-            requirements.delete_if { |r| name_for(r) == succ.name }
+
+            all_successor_names = succ.recursive_successors.map(&:name)
+
+            requirements.delete_if do |requirement|
+              requirement_name = name_for(requirement)
+              (requirement_name == succ.name) || all_successor_names.include?(requirement_name)
+            end
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,4 +33,6 @@ require 'molinillo'
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
- [x] CHANGELOG
- [x] Tests

---

I'm investigating an issue (https://github.com/berkshelf/solve/issues/57) in the solve library, which is using Molinillo. I was able to add a reproduction case (https://github.com/berkshelf/solve/commit/b84500e80c22e0596b530838f7a7d299f6f9f870) as a RSpec test for solve, which fails with the following:

```
  1) Solutions when using the ruby solver repro case?
     Failure/Error: activated.vertex_named(name).payload ? 0 : 1,
     
     NoMethodError:
       undefined method `payload' for nil:NilClass
     # ./lib/solve/ruby_solver.rb:145:in `block in sort_dependencies'
     # ./lib/solve/ruby_solver.rb:142:in `each'
     # ./lib/solve/ruby_solver.rb:142:in `sort_by'
     # ./lib/solve/ruby_solver.rb:142:in `sort_dependencies'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:131:in `block (2 levels) in <class:Resolution>'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:431:in `push_state_for_requirements'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:423:in `require_nested_dependencies_for'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:411:in `activate_spec'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:353:in `attempt_to_swap_possibility'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:333:in `attempt_to_activate_existing_spec'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:318:in `attempt_to_activate'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:147:in `process_topmost_state'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolution.rb:72:in `resolve'
     # /Users/ddeleo/contrib/Molinillo/lib/molinillo/resolver.rb:42:in `resolve'
     # ./lib/solve/ruby_solver.rb:198:in `resolve_with_error_wrapping'
     # ./lib/solve/ruby_solver.rb:75:in `resolve'
     # ./lib/solve.rb:64:in `it!'
     # ./spec/acceptance/ruby_solver_solutions_spec.rb:300:in `block (2 levels) in <top (required)>'
```

When I enable Molinillo's debugging and add some printf debugging of my own, what I find is that a requirement is added for a grandchild, but the child later gets swapped. The `#detach_vertex_named` method is recursive, so it removes the grandchild's vertex, but the requirements removal is not recursive, so there's a "zombie" requirement, so that `activated.vertex_named(name)` returns `nil`.

In more concrete terms (these are all Chef cookbooks), there is a cookbook named "build-essential". The old version of this depends on a cookbook named "7-zip"; the new version of it depends on a replacement named "seven_zip". Both "7-zip" and "seven_zip" depend on a cookbook called "windows". When solving the dependencies, Molinillo at first picks the solution using the new version of "build-essential", and activates "seven_zip" and "windows". This conflicts with a version requirement elsewhere (we need the older "build-essential"), so Molinillo calls `#fixup_swapped_children` to remove "seven_zip". In the meantime, the requirements array has collected a requirement for the windows cookbook. Since only the vertices are recursively removed, the windows requirement stays there, until it triggers the exception case for `activated.vertex_named("windows") #=> nil`.

As for the code in this pull request:
1. I'm not sure if this is the proper approach to solving the problem; I don't have a good understanding of most of the moving parts here
2. Even if the approach is right, it's only a partial solution for the reason I wrote in the code comment.
3. In any case there of course should be a test, but my repro case is a little picky based on the order things are returned from `#sort_dependencies` and I haven't yet looked at how the JSON fixtures work.

Despite that, it does pass Molinillo's specs, and it fixes my repro case.