### PR TITLE
activated dependencies are input to read only operations so don't dup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* For performance, don't needlessly dup objects in
+  `Resolution#push_state_for_requirements`.
+  [Joe Rafaniello](https://github.com/jrafanie)
 
 ##### Bug Fixes
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -433,7 +433,7 @@ module Molinillo
       # requirements
       # @param [Array] new_requirements
       # @return [void]
-      def push_state_for_requirements(new_requirements, requires_sort = true, new_activated = activated.dup)
+      def push_state_for_requirements(new_requirements, requires_sort = true, new_activated = activated)
         new_requirements = sort_dependencies(new_requirements.uniq, new_activated, conflicts) if requires_sort
         new_requirement = new_requirements.shift
         new_name = new_requirement ? name_for(new_requirement) : ''


### PR DESCRIPTION
I don't know if this is the right fix.  I feel like this is a bandaid for DependencyGraph#initialize_copy being slow but it also seems odd that we're calling .dup on already calculated graphs.  I didn't see where we were intentionally modifying the graphs, so it's unclear if .dup is needed.  It seems as though we're calling .dup because the DependencyGraph uses these inputs for the struct's attributes.  

Note, I didn't add a test since it's not a change in functionality but I verified all tests pass locally.  Feel free to 👎  this PR if you have better ideas on how to fix this.  I ultimately don't care about this change, I'd rather Molinillo not do more work than it needs to do.

We pass activated to sort_dependencies and DependencyState.new, both operations
that probably shouldn't be modifying any of the dependency graphs.

Note: activated contains DependencyGraph objects and calling .dup is not a fast
operation because it has to copy the graph and rebuild the vertices.

For a large Rails application that runs Molinillo::Resolver::Resolution#attempt_to_activate
477 times when running bundle or require 'bundler/setup', this saves roughly **10%** time.

Note, for reference, I also cloned the rails git repo (a framework with a good number of dependencies but still much smaller than many applications) and did the same timing before and after applying this single change to my local bundler (1.11.2) and it saves **5%** time.

Below is a ruby prof graph for my rails app at work (before this PR) requiring 'bundler/setup'.

![image](https://cloud.githubusercontent.com/assets/19339/14653222/f84f381a-0645-11e6-9f89-9a9d448735bd.png)

Note, that [pop_possibility_state is also dup'ing these graphs](https://github.com/CocoaPods/Molinillo/blob/6e3551157a211d2e8ac6463d5cab70a4b6e9d28a/lib/molinillo/state.rb#L39) and spends even more time doing this but I couldn't figure out how to easily prevent this as the test suite fails after removing the .dup, so imagine something is expecting duplicated objects.