### PR TITLE
Add an oplog to DependencyGraph to avoid copying it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Lint/UnusedMethodArgument:
   Exclude:
     - 'lib/molinillo/modules/**/*'
 
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
 # CocoaPods default overrides
 
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ##### Enhancements
 
-* None.  
+* Add an operation log to `DependencyGraph` to eliminate the need for graph
+  copies during dependency resolution, resulting in a 3-100x speedup and
+  reduction in allocations.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [bundler#4376](https://github.com/bundler/bundler/issues/4376)
+
+* Remove all metaprogramming to reduce array allocation overhead and improve
+  discoverability.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
 

--- a/lib/molinillo/delegates/resolution_state.rb
+++ b/lib/molinillo/delegates/resolution_state.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+module Molinillo
+  # @!visibility private
+  module Delegates
+    # Delegates all {Molinillo::ResolutionState} methods to a `#state` property.
+    module ResolutionState
+      # (see Molinillo::ResolutionState#name)
+      def name
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.name
+      end
+
+      # (see Molinillo::ResolutionState#requirements)
+      def requirements
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.requirements
+      end
+
+      # (see Molinillo::ResolutionState#activated)
+      def activated
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.activated
+      end
+
+      # (see Molinillo::ResolutionState#requirement)
+      def requirement
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.requirement
+      end
+
+      # (see Molinillo::ResolutionState#possibilities)
+      def possibilities
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.possibilities
+      end
+
+      # (see Molinillo::ResolutionState#depth)
+      def depth
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.depth
+      end
+
+      # (see Molinillo::ResolutionState#conflicts)
+      def conflicts
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.conflicts
+      end
+    end
+  end
+end

--- a/lib/molinillo/delegates/specification_provider.rb
+++ b/lib/molinillo/delegates/specification_provider.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+module Molinillo
+  module Delegates
+    # Delegates all {Molinillo::SpecificationProvider} methods to a
+    # `#specification_provider` property.
+    module SpecificationProvider
+      # (see Molinillo::SpecificationProvider#search_for)
+      def search_for(dependency)
+        with_no_such_dependency_error_handling do
+          specification_provider.search_for(dependency)
+        end
+      end
+
+      # (see Molinillo::SpecificationProvider#dependencies_for)
+      def dependencies_for(specification)
+        with_no_such_dependency_error_handling do
+          specification_provider.dependencies_for(specification)
+        end
+      end
+
+      # (see Molinillo::SpecificationProvider#requirement_satisfied_by?)
+      def requirement_satisfied_by?(requirement, activated, spec)
+        with_no_such_dependency_error_handling do
+          specification_provider.requirement_satisfied_by?(requirement, activated, spec)
+        end
+      end
+
+      # (see Molinillo::SpecificationProvider#name_for)
+      def name_for(dependency)
+        with_no_such_dependency_error_handling do
+          specification_provider.name_for(dependency)
+        end
+      end
+
+      # (see Molinillo::SpecificationProvider#name_for_explicit_dependency_source)
+      def name_for_explicit_dependency_source
+        with_no_such_dependency_error_handling do
+          specification_provider.name_for_explicit_dependency_source
+        end
+      end
+
+      # (see Molinillo::SpecificationProvider#name_for_locking_dependency_source)
+      def name_for_locking_dependency_source
+        with_no_such_dependency_error_handling do
+          specification_provider.name_for_locking_dependency_source
+        end
+      end
+
+      # (see Molinillo::SpecificationProvider#sort_dependencies)
+      def sort_dependencies(dependencies, activated, conflicts)
+        with_no_such_dependency_error_handling do
+          specification_provider.sort_dependencies(dependencies, activated, conflicts)
+        end
+      end
+
+      # (see Molinillo::SpecificationProvider#allow_missing?)
+      def allow_missing?(dependency)
+        with_no_such_dependency_error_handling do
+          specification_provider.allow_missing?(dependency)
+        end
+      end
+
+      private
+
+      # Ensures any raised {NoSuchDependencyError} has its
+      # {NoSuchDependencyError#required_by} set.
+      # @yield
+      def with_no_such_dependency_error_handling
+        yield
+      rescue NoSuchDependencyError => error
+        if state
+          vertex = activated.vertex_named(name_for(error.dependency))
+          error.required_by += vertex.incoming_edges.map { |e| e.origin.name }
+          error.required_by << name_for_explicit_dependency_source unless vertex.explicit_requirements.empty?
+        end
+        raise
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -168,7 +168,7 @@ module Molinillo
       if destination.path_to?(origin)
         raise CircularDependencyError.new([origin, destination])
       end
-      log.add_edge(self, origin, destination, requirement)
+      add_edge_no_circular(origin, destination, requirement)
     end
 
     def set_payload(name, payload)
@@ -180,10 +180,7 @@ module Molinillo
     # Adds a new {Edge} to the dependency graph without checking for
     # circularity.
     def add_edge_no_circular(origin, destination, requirement)
-      edge = Edge.new(origin, destination, requirement)
-      origin.outgoing_edges << edge
-      destination.incoming_edges << edge
-      edge
+      log.add_edge_no_circular(self, origin.name, destination.name, requirement)
     end
 
     # A vertex in a {DependencyGraph} that encapsulates a {#name} and a

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -89,18 +89,18 @@ module Molinillo
     end
 
     def to_dot
-      String.new.tap do |dot|
-        dot << "digraph G {\n"
-        vertices.each do |n, v|
-          dot << "  #{n} [label=\"{#{n}|#{v.payload.to_s}}\"]\n"
-          v.outgoing_edges.each do |e|
-            dot << "  #{e.origin.name} -> #{e.destination.name}"
-            dot << " [label=\"#{e.requirement}\"]" if e.requirement
-            dot << "\n"
-          end
+      dot_vertices = []
+      dot_edges = []
+      vertices.each do |n, v|
+        dot_vertices << "  #{n} [label=\"{#{n}|#{v.payload}}\"]"
+        v.outgoing_edges.each do |e|
+          dot_edges << "  #{e.origin.name} -> #{e.destination.name} [label=\"#{e.requirement}\"]"
         end
-        dot << "}"
       end
+      dot_vertices.sort!
+      dot_edges.sort!
+      dot = dot_vertices.unshift('digraph G {').push('') + dot_edges.push('}')
+      dot.join("\n")
     end
 
     # @return [Boolean] whether the two dependency graphs are equal, determined

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -88,6 +88,21 @@ module Molinillo
       "#{self.class}:#{vertices.values.inspect}"
     end
 
+    def to_dot
+      String.new.tap do |dot|
+        dot << "digraph G {\n"
+        vertices.each do |n, v|
+          dot << "  #{n} [label=\"{#{n}|#{v.payload.to_s}}\"]\n"
+          v.outgoing_edges.each do |e|
+            dot << "  #{e.origin.name} -> #{e.destination.name}"
+            dot << " [label=\"#{e.requirement}\"]" if e.requirement
+            dot << "\n"
+          end
+        end
+        dot << "}"
+      end
+    end
+
     # @return [Boolean] whether the two dependency graphs are equal, determined
     #   by a recursive traversal of each {#root_vertices} and its
     #   {Vertex#successors}

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -204,7 +204,7 @@ module Molinillo
       # @param [String] name see {#name}
       # @param [Object] payload see {#payload}
       def initialize(name, payload)
-        @name = name
+        @name = name.frozen? ? name : name.dup.freeze
         @payload = payload
         @explicit_requirements = []
         @outgoing_edges = []

--- a/lib/molinillo/dependency_graph/action.rb
+++ b/lib/molinillo/dependency_graph/action.rb
@@ -1,0 +1,17 @@
+module Molinillo
+  class DependencyGraph
+    class Action
+      def self.name
+        raise 'Abstract'
+      end
+
+      def up(_graph)
+        raise 'Abstract'
+      end
+
+      def down(_graph)
+        raise 'Abstract'
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph/action.rb
+++ b/lib/molinillo/dependency_graph/action.rb
@@ -1,19 +1,35 @@
+# frozen_string_literal: true
 module Molinillo
   class DependencyGraph
+    # An action that modifies a {DependencyGraph} that is reversible.
+    # @abstract
     class Action
+      # rubocop:disable Lint/UnusedMethodArgument
+
+      # @return [Symbol] The name of the action.
       def self.name
         raise 'Abstract'
       end
 
-      def up(_graph)
+      # Performs the action on the given graph.
+      # @param  [DependencyGraph] graph the graph to perform the action on.
+      # @return [Void]
+      def up(graph)
         raise 'Abstract'
       end
 
-      def down(_graph)
+      # Reverses the action on the given graph.
+      # @param  [DependencyGraph] graph the graph to reverse the action on.
+      # @return [Void]
+      def down(graph)
         raise 'Abstract'
       end
 
-      attr_accessor :previous, :next
+      # @return [Action,Nil] The previous action
+      attr_accessor :previous
+
+      # @return [Action,Nil] The next action
+      attr_accessor :next
     end
   end
 end

--- a/lib/molinillo/dependency_graph/action.rb
+++ b/lib/molinillo/dependency_graph/action.rb
@@ -12,6 +12,8 @@ module Molinillo
       def down(_graph)
         raise 'Abstract'
       end
+
+      attr_accessor :previous, :next
     end
   end
 end

--- a/lib/molinillo/dependency_graph/add_edge_no_circular.rb
+++ b/lib/molinillo/dependency_graph/add_edge_no_circular.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'molinillo/dependency_graph/action'
+module Molinillo
+  class DependencyGraph
+    # @!visibility private
+    # (see DependencyGraph#add_edge_no_circular)
+    class AddEdgeNoCircular < Action
+      # @!group Action
+
+      # (see Action.name)
+      def self.name
+        :add_vertex
+      end
+
+      # (see Action#up)
+      def up(graph)
+        edge = make_edge(graph)
+        edge.origin.outgoing_edges << edge
+        edge.destination.incoming_edges << edge
+        edge
+      end
+
+      # (see Action#down)
+      def down(graph)
+        edge = make_edge(graph)
+        edge.origin.outgoing_edges.delete(edge)
+        edge.destination.incoming_edges.delete(edge)
+      end
+
+      # @!group AddEdgeNoCircular
+
+      # @return [String] the name of the origin of the edge
+      attr_reader :origin
+
+      # @return [String] the name of the destination of the edge
+      attr_reader :destination
+
+      # @return [Object] the requirement that the edge represents
+      attr_reader :requirement
+
+      # @param  [DependencyGraph] graph the graph to find vertices from
+      # @return [Edge] The edge this action adds
+      def make_edge(graph)
+        Edge.new(graph.vertex_named(origin), graph.vertex_named(destination), requirement)
+      end
+
+      # Initialize an action to add an edge to a dependency graph
+      # @param [String] origin the name of the origin of the edge
+      # @param [String] destination the name of the destination of the edge
+      # @param [Object] requirement the requirement that the edge represents
+      def initialize(origin, destination, requirement)
+        @origin = origin
+        @destination = destination
+        @requirement = requirement
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph/add_vertex.rb
+++ b/lib/molinillo/dependency_graph/add_vertex.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require 'molinillo/dependency_graph/action'
+module Molinillo
+  class DependencyGraph
+    # @!visibility private
+    # (see DependencyGraph#add_vertex)
+    class AddVertex < Action # :nodoc:
+      # @!group Action
+
+      # (see Action.name)
+      def self.name
+        :add_vertex
+      end
+
+      # (see Action#up)
+      def up(graph)
+        if existing = graph.vertices[name]
+          @existing_payload = existing.payload
+          @existing_root = existing.root
+        end
+        vertex = existing || Vertex.new(name, payload)
+        graph.vertices[vertex.name] = vertex
+        vertex.payload ||= payload
+        vertex.root ||= root
+        vertex
+      end
+
+      # (see Action#down)
+      def down(graph)
+        if defined?(@existing_payload)
+          vertex = graph.vertices[name]
+          vertex.payload = @existing_payload
+          vertex.root = @existing_root
+        else
+          graph.vertices.delete(name)
+        end
+      end
+
+      # @!group AddVertex
+
+      # @return [String] the name of the vertex
+      attr_reader :name
+
+      # @return [Object] the payload for the vertex
+      attr_reader :payload
+
+      # @return [Boolean] whether the vertex is root or not
+      attr_reader :root
+
+      # Initialize an action to add a vertex to a dependency graph
+      # @param [String] name the name of the vertex
+      # @param [Object] payload the payload for the vertex
+      # @param [Boolean] root whether the vertex is root or not
+      def initialize(name, payload, root)
+        @name = name
+        @payload = payload
+        @root = root
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph/detach_vertex_named.rb
+++ b/lib/molinillo/dependency_graph/detach_vertex_named.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'molinillo/dependency_graph/action'
+module Molinillo
+  class DependencyGraph
+    # @!visibility private
+    # @see DependencyGraph#detach_vertex_named
+    class DetachVertexNamed < Action
+      # @!group Action
+
+      # (see Action#name)
+      def self.name
+        :add_vertex
+      end
+
+      # (see Action#up)
+      def up(graph)
+        return unless @vertex = graph.vertices.delete(name)
+        @vertex.outgoing_edges.each do |e|
+          v = e.destination
+          v.incoming_edges.delete(e)
+          graph.detach_vertex_named(v.name) unless v.root? || v.predecessors.any?
+        end
+        @vertex.incoming_edges.each do |e|
+          v = e.origin
+          v.outgoing_edges.delete(e)
+        end
+      end
+
+      # (see Action#down)
+      def down(graph)
+        return unless @vertex
+        graph.vertices[@vertex.name] = @vertex
+        @vertex.outgoing_edges.each do |e|
+          e.destination.incoming_edges << e
+        end
+        @vertex.incoming_edges.each do |e|
+          e.origin.outgoing_edges << e
+        end
+      end
+
+      # @!group DetachVertexNamed
+
+      # @return [String] the name of the vertex to detach
+      attr_reader :name
+
+      # Initialize an action to detach a vertex from a dependency graph
+      # @param [String] name the name of the vertex to detach
+      def initialize(name)
+        @name = name
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph/log.rb
+++ b/lib/molinillo/dependency_graph/log.rb
@@ -1,150 +1,69 @@
-require 'molinillo/dependency_graph/action'
+# frozen_string_literal: true
+require 'molinillo/dependency_graph/add_edge_no_circular'
+require 'molinillo/dependency_graph/add_vertex'
+require 'molinillo/dependency_graph/detach_vertex_named'
+require 'molinillo/dependency_graph/set_payload'
+require 'molinillo/dependency_graph/tag'
 
 module Molinillo
   class DependencyGraph
+    # A log for dependency graph actions
     class Log
-      LOG_ACTIONS = !ENV['MOLINILLO_DEBUG_GRAPH'].nil?
-
-      def self.action(name__, parameters = nil, &blk)
-        name__ = name__.to_sym
-        cls = Class.new(Action) do
-          define_singleton_method(:name) { name__ }
-          if parameters || (method = begin
-                                       DependencyGraph.instance_method(name__)
-                                     rescue
-                                       nil
-                                     end)
-            parameters ||= method.parameters.map(&:last)
-            module_eval <<-EOS
-              #{parameters.map { |param| "attr_reader(:#{param});" }.join}
-              define_method(:initialize) do |#{parameters.join(', ')}|
-                #{parameters.map { |p| "@#{p} = #{p};" }.join}
-                @args = [#{parameters.join(', ')}]
-              end
-
-              define_method(:_log) do |direction|
-                $stderr.puts "[\#{direction}] #{name}(\#{@args.map(&:inspect).join(', ')})"
-              end
-            EOS
-          end
-          module_exec(&blk)
-        end
-
-        define_method(name__) do |graph, *args|
-          action = cls.new(*args)
-          action.previous = @current_action
-          @current_action.next = action if @current_action
-          @current_action = action
-          @first_action ||= action
-          action._log(:up) if LOG_ACTIONS
-          action.up(graph)
-        end
-      end
-
+      # Initializes an empty log
       def initialize
         @current_action = @first_action = nil
       end
 
-      action(:tag, %w(tag)) do
-        def down(graph); end
+      # @!macro [new] action
+      #   {include:DependencyGraph#$0}
+      #   @param [Graph] graph the graph to perform the action on
+      #   @param (see DependencyGraph#$0)
+      #   @return (see DependencyGraph#$0)
 
-        def up(graph); end
+      # @macro action
+      def tag(graph, tag)
+        push_action(graph, Tag.new(tag))
       end
 
-      action(:add_vertex) do
-        def up(graph)
-          if existing = graph.vertices[name]
-            @existing_payload = existing.payload
-            @existing_root = existing.root
-          end
-          vertex = existing || Vertex.new(name, payload)
-          graph.vertices[vertex.name] = vertex
-          vertex.payload ||= payload
-          vertex.root ||= root
-          vertex
-        end
-
-        def down(graph)
-          if defined?(@existing_payload)
-            vertex = graph.vertices[name]
-            vertex.payload = @existing_payload
-            vertex.root = @existing_root
-          else
-            graph.vertices.delete(name)
-          end
-        end
+      # @macro action
+      def add_vertex(graph, name, payload, root)
+        push_action(graph, AddVertex.new(name, payload, root))
       end
 
-      action(:detach_vertex_named) do
-        def up(graph)
-          return unless @vertex = graph.vertices.delete(name)
-          @vertex.outgoing_edges.each do |e|
-            v = e.destination
-            v.incoming_edges.delete(e)
-            graph.detach_vertex_named(v.name) unless v.root? || v.predecessors.any?
-          end
-          @vertex.incoming_edges.each do |e|
-            v = e.origin
-            v.outgoing_edges.delete(e)
-          end
-        end
-
-        def down(graph)
-          return unless @vertex
-          graph.vertices[@vertex.name] = @vertex
-          @vertex.outgoing_edges.each do |e|
-            e.destination.incoming_edges << e
-          end
-          @vertex.incoming_edges.each do |e|
-            e.origin.outgoing_edges << e
-          end
-        end
+      # @macro action
+      def detach_vertex_named(graph, name)
+        push_action(graph, DetachVertexNamed.new(name))
       end
 
-      action(:add_edge_no_circular) do
-        def up(graph)
-          edge = make_edge(graph)
-          edge.origin.outgoing_edges << edge
-          edge.destination.incoming_edges << edge
-          edge
-        end
-
-        def down(graph)
-          edge = make_edge(graph)
-          edge.origin.outgoing_edges.delete(edge)
-          edge.destination.incoming_edges.delete(edge)
-        end
-
-        def make_edge(graph)
-          Edge.new(graph.vertex_named(origin), graph.vertex_named(destination), requirement)
-        end
+      # @macro action
+      def add_edge_no_circular(graph, origin, destination, requirement)
+        push_action(graph, AddEdgeNoCircular.new(origin, destination, requirement))
       end
 
-      action(:set_payload) do
-        def up(graph)
-          vertex = graph.vertex_named(name)
-          @old_payload = vertex.payload
-          vertex.payload = payload
-        end
-
-        def down(graph)
-          graph.vertex_named(name).payload = @old_payload
-        end
+      # @macro action
+      def set_payload(graph, name, payload)
+        push_action(graph, SetPayload.new(name, payload))
       end
 
+      # Pops the most recent action from the log and undoes the action
+      # @param [DependencyGraph] graph
+      # @return [Action] the action that was popped off the log
       def pop!(graph)
         return unless action = @current_action
         unless @current_action = action.previous
           @first_action = nil
         end
-        action._log(:down) if LOG_ACTIONS
         action.down(graph)
         action
       end
 
       extend Enumerable
 
+      # @!visibility private
+      # Enumerates each action in the log
+      # @yield [Action]
       def each
+        return enum_for unless block_given?
         action = @first_action
         loop do
           break unless action
@@ -154,7 +73,11 @@ module Molinillo
         self
       end
 
+      # @!visibility private
+      # Enumerates each action in the log in reverse order
+      # @yield [Action]
       def reverse_each
+        return enum_for(:reverse_each) unless block_given?
         action = @current_action
         loop do
           break unless action
@@ -164,12 +87,27 @@ module Molinillo
         self
       end
 
+      # @macro action
       def rewind_to(graph, tag)
         loop do
           action = pop!(graph)
           raise "No tag #{tag.inspect} found" unless action
           break if action.class.name == :tag && action.tag == tag
         end
+      end
+
+      private
+
+      # Adds the given action to the log, running the action
+      # @param [DependencyGraph] graph
+      # @param [Action] action
+      # @return The value returned by `action.up`
+      def push_action(graph, action)
+        action.previous = @current_action
+        @current_action.next = action if @current_action
+        @current_action = action
+        @first_action ||= action
+        action.up(graph)
       end
     end
   end

--- a/lib/molinillo/dependency_graph/log.rb
+++ b/lib/molinillo/dependency_graph/log.rb
@@ -75,8 +75,9 @@ module Molinillo
           end
         end
 
-        def down(_graph)
+        def down(graph)
           return unless @vertex
+          graph.vertices[name] = @vertex
           @vertex.outgoing_edges.each do |e|
             e.destination.incoming_edges << e
           end

--- a/lib/molinillo/dependency_graph/log.rb
+++ b/lib/molinillo/dependency_graph/log.rb
@@ -57,7 +57,8 @@ module Molinillo
             @existing_payload = existing.payload
             @existing_root = existing.root
           end
-          vertex = graph.vertices[name] ||= Vertex.new(name, payload)
+          vertex = existing || Vertex.new(name, payload)
+          graph.vertices[vertex.name] = vertex
           vertex.payload ||= payload
           vertex.root ||= root
           vertex
@@ -90,7 +91,7 @@ module Molinillo
 
         def down(graph)
           return unless @vertex
-          graph.vertices[name] = @vertex
+          graph.vertices[@vertex.name] = @vertex
           @vertex.outgoing_edges.each do |e|
             e.destination.incoming_edges << e
           end

--- a/lib/molinillo/dependency_graph/log.rb
+++ b/lib/molinillo/dependency_graph/log.rb
@@ -1,0 +1,135 @@
+require 'molinillo/dependency_graph/action'
+
+module Molinillo
+  class DependencyGraph
+    class Log
+      def self.action(name__, parameters = nil, &blk)
+        name__ = name__.to_sym
+        cls = Class.new(Action) do
+          define_singleton_method(:name) { name__ }
+          if parameters || (method = begin
+                                       DependencyGraph.instance_method(name__)
+                                     rescue
+                                       nil
+                                     end)
+            parameters ||= method.parameters.map(&:last)
+            module_eval <<-EOS
+              #{parameters.map { |param| "attr_reader(:#{param});" }.join}
+              define_method(:initialize) do |#{parameters.join(', ')}|
+                #{parameters.map { |p| "@#{p} = #{p};" }.join}
+                @args = [#{parameters.join(', ')}]
+              end
+            EOS
+          end
+          module_exec(&blk)
+        end
+
+        define_method(name__) do |graph, *args|
+          action = cls.new(*args)
+          @actions << action
+          action.up(graph)
+        end
+      end
+
+      def initialize
+        @actions = []
+      end
+
+      action(:tag, %w(tag)) do
+        def down(graph); end
+
+        def up(graph); end
+      end
+
+      action(:add_vertex) do
+        def up(graph)
+          existing = graph.vertices[name]
+          @existing = existing && [existing.payload, existing.root]
+          vertex = graph.vertices[name] ||= Vertex.new(name, payload)
+          vertex.payload ||= payload
+          vertex.root ||= root
+          vertex
+        end
+
+        def down(graph)
+          if @existing
+            vertex = graph.vertices[name]
+            vertex.payload, vertex.root = @existing
+          else
+            graph.vertices.delete(name)
+          end
+        end
+      end
+
+      action(:detach_vertex_named) do
+        def up(graph)
+          return unless @vertex = graph.vertices.delete(name)
+          @vertex.outgoing_edges.each do |e|
+            v = e.destination
+            v.incoming_edges.delete(e)
+            graph.detach_vertex_named(v.name) unless v.root? || v.predecessors.any?
+          end
+          @vertex.incoming_edges.each do |e|
+            v = e.origin
+            v.outgoing_edges.delete(e)
+          end
+        end
+
+        def down(_graph)
+          return unless @vertex
+          @vertex.outgoing_edges.each do |e|
+            e.destination.incoming_edges << e
+          end
+          @vertex.incoming_edges.each do |e|
+            e.origin.outgoing_edges << e
+          end
+        end
+      end
+
+      action(:add_edge) do
+        def up(_graph)
+          edge = make_edge
+          origin.outgoing_edges << edge
+          destination.incoming_edges << edge
+          edge
+        end
+
+        def down(_graph)
+          edge = make_edge
+          origin.outgoing_edges.delete(edge)
+          destination.incoming_edges.delete(edge)
+        end
+
+        def make_edge
+          Edge.new(origin, destination, requirement)
+        end
+      end
+
+      action(:set_payload) do
+        def up(graph)
+          vertex = graph.vertex_named(name)
+          @old_payload = vertex.payload
+          vertex.payload = payload
+        end
+
+        def down(graph)
+          graph.vertex_named(name).payload = @old_payload
+        end
+      end
+
+      def pop!(graph)
+        @actions.pop.tap do |action|
+          action.down(graph) if action
+        end
+      end
+
+      def rewind_to(graph, tag)
+        loop do
+          action = pop!(graph)
+          raise "No tag #{tag.inspect} found" unless action
+          break if action.class.name == :tag && action.tag == tag
+        end
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph/set_payload.rb
+++ b/lib/molinillo/dependency_graph/set_payload.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'molinillo/dependency_graph/action'
+module Molinillo
+  class DependencyGraph
+    # @!visibility private
+    # @see DependencyGraph#set_payload
+    class SetPayload < Action # :nodoc:
+      # @!group Action
+
+      # (see Action.name)
+      def self.name
+        :set_payload
+      end
+
+      # (see Action#up)
+      def up(graph)
+        vertex = graph.vertex_named(name)
+        @old_payload = vertex.payload
+        vertex.payload = payload
+      end
+
+      # (see Action#down)
+      def down(graph)
+        graph.vertex_named(name).payload = @old_payload
+      end
+
+      # @!group SetPayload
+
+      # @return [String] the name of the vertex
+      attr_reader :name
+
+      # @return [Object] the payload for the vertex
+      attr_reader :payload
+
+      # Initialize an action to add set the payload for a vertex in a dependency
+      # graph
+      # @param [String] name the name of the vertex
+      # @param [Object] payload the payload for the vertex
+      def initialize(name, payload)
+        @name = name
+        @payload = payload
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph/tag.rb
+++ b/lib/molinillo/dependency_graph/tag.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'molinillo/dependency_graph/action'
+module Molinillo
+  class DependencyGraph
+    # @!visibility private
+    # @see DependencyGraph#tag
+    class Tag < Action
+      # @!group Action
+
+      # (see Action.name)
+      def self.name
+        :tag
+      end
+
+      # (see Action#up)
+      def up(_graph)
+      end
+
+      # (see Action#down)
+      def down(_graph)
+      end
+
+      # @!group Tag
+
+      # @return [Object] An opaque tag
+      attr_reader :tag
+
+      # Initialize an action to tag a state of a dependency graph
+      # @param [Object] tag an opaque tag
+      def initialize(tag)
+        @tag = tag
+      end
+    end
+  end
+end

--- a/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/molinillo/dependency_graph/vertex.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+module Molinillo
+  class DependencyGraph
+    # A vertex in a {DependencyGraph} that encapsulates a {#name} and a
+    # {#payload}
+    class Vertex
+      # @return [String] the name of the vertex
+      attr_accessor :name
+
+      # @return [Object] the payload the vertex holds
+      attr_accessor :payload
+
+      # @return [Arrary<Object>] the explicit requirements that required
+      #   this vertex
+      attr_reader :explicit_requirements
+
+      # @return [Boolean] whether the vertex is considered a root vertex
+      attr_accessor :root
+      alias root? root
+
+      # Initializes a vertex with the given name and payload.
+      # @param [String] name see {#name}
+      # @param [Object] payload see {#payload}
+      def initialize(name, payload)
+        @name = name.frozen? ? name : name.dup.freeze
+        @payload = payload
+        @explicit_requirements = []
+        @outgoing_edges = []
+        @incoming_edges = []
+      end
+
+      # @return [Array<Object>] all of the requirements that required
+      #   this vertex
+      def requirements
+        incoming_edges.map(&:requirement) + explicit_requirements
+      end
+
+      # @return [Array<Edge>] the edges of {#graph} that have `self` as their
+      #   {Edge#origin}
+      attr_accessor :outgoing_edges
+
+      # @return [Array<Edge>] the edges of {#graph} that have `self` as their
+      #   {Edge#destination}
+      attr_accessor :incoming_edges
+
+      # @return [Array<Vertex>] the vertices of {#graph} that have an edge with
+      #   `self` as their {Edge#destination}
+      def predecessors
+        incoming_edges.map(&:origin)
+      end
+
+      # @return [Array<Vertex>] the vertices of {#graph} where `self` is a
+      #   {#descendent?}
+      def recursive_predecessors
+        vertices = predecessors
+        vertices += vertices.map(&:recursive_predecessors).flatten(1)
+        vertices.uniq!
+        vertices
+      end
+
+      # @return [Array<Vertex>] the vertices of {#graph} that have an edge with
+      #   `self` as their {Edge#origin}
+      def successors
+        outgoing_edges.map(&:destination)
+      end
+
+      # @return [Array<Vertex>] the vertices of {#graph} where `self` is an
+      #   {#ancestor?}
+      def recursive_successors
+        vertices = successors
+        vertices += vertices.map(&:recursive_successors).flatten(1)
+        vertices.uniq!
+        vertices
+      end
+
+      # @return [String] a string suitable for debugging
+      def inspect
+        "#{self.class}:#{name}(#{payload.inspect})"
+      end
+
+      # @return [Boolean] whether the two vertices are equal, determined
+      #   by a recursive traversal of each {Vertex#successors}
+      def ==(other)
+        shallow_eql?(other) &&
+          successors.to_set == other.successors.to_set
+      end
+
+      # @param  [Vertex] other the other vertex to compare to
+      # @return [Boolean] whether the two vertices are equal, determined
+      #   solely by {#name} and {#payload} equality
+      def shallow_eql?(other)
+        other &&
+          name == other.name &&
+          payload == other.payload
+      end
+
+      alias eql? ==
+
+      # @return [Fixnum] a hash for the vertex based upon its {#name}
+      def hash
+        name.hash
+      end
+
+      # Is there a path from `self` to `other` following edges in the
+      # dependency graph?
+      # @return true iff there is a path following edges within this {#graph}
+      def path_to?(other)
+        equal?(other) || successors.any? { |v| v.path_to?(other) }
+      end
+
+      alias descendent? path_to?
+
+      # Is there a path from `other` to `self` following edges in the
+      # dependency graph?
+      # @return true iff there is a path following edges within this {#graph}
+      def ancestor?(other)
+        other.path_to?(self)
+      end
+
+      alias is_reachable_from? ancestor?
+    end
+  end
+end

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -124,27 +124,11 @@ module Molinillo
       require 'molinillo/state'
       require 'molinillo/modules/specification_provider'
 
-      ResolutionState.new.members.each do |member|
-        define_method member do |*args, &block|
-          current_state = state || ResolutionState.empty
-          current_state.send(member, *args, &block)
-        end
-      end
+      require 'molinillo/delegates/resolution_state'
+      require 'molinillo/delegates/specification_provider'
 
-      SpecificationProvider.instance_methods(false).each do |instance_method|
-        define_method instance_method do |*args, &block|
-          begin
-            specification_provider.send(instance_method, *args, &block)
-          rescue NoSuchDependencyError => error
-            if state
-              vertex = activated.vertex_named(name_for(error.dependency))
-              error.required_by += vertex.incoming_edges.map { |e| e.origin.name }
-              error.required_by << name_for_explicit_dependency_source unless vertex.explicit_requirements.empty?
-            end
-            raise
-          end
-        end
-      end
+      include Molinillo::Delegates::ResolutionState
+      include Molinillo::Delegates::SpecificationProvider
 
       # Processes the topmost available {RequirementState} on the stack
       # @return [void]

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -262,6 +262,8 @@ module Molinillo
           name_for_locking_dependency_source => Array(locked_requirement_named(name)),
         }
         vertex.incoming_edges.each { |edge| (requirements[edge.origin.payload] ||= []).unshift(edge.requirement) }
+        activated_by_name = {}
+        activated.each { |v| activated_by_name[v.name] = v.payload if v.payload }
         conflicts[name] = Conflict.new(
           requirement,
           Hash[requirements.select { |_, r| !r.empty? }],
@@ -269,7 +271,7 @@ module Molinillo
           possibility,
           locked_requirement_named(name),
           requirement_trees,
-          Hash[activated.map { |v| [v.name, v.payload] }.select(&:last)]
+          activated_by_name
         )
       end
 
@@ -443,7 +445,7 @@ module Molinillo
       def push_state_for_requirements(new_requirements, requires_sort = true, new_activated = activated)
         new_requirements = sort_dependencies(new_requirements.uniq, new_activated, conflicts) if requires_sort
         new_requirement = new_requirements.shift
-        new_name = new_requirement ? name_for(new_requirement) : ''
+        new_name = new_requirement ? name_for(new_requirement) : ''.freeze
         possibilities = new_requirement ? search_for(new_requirement) : []
         handle_missing_or_push_dependency_state DependencyState.new(
           new_name, new_requirements, new_activated,

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -255,7 +255,9 @@ module Molinillo
         locked_requirement = locked_requirement_named(name)
 
         requirements = {}
-        requirements[name_for_explicit_dependency_source] = vertex.explicit_requirements unless vertex.explicit_requirements.empty?
+        unless vertex.explicit_requirements.empty?
+          requirements[name_for_explicit_dependency_source] = vertex.explicit_requirements
+        end
         requirements[name_for_locking_dependency_source] = [locked_requirement] if locked_requirement
         vertex.incoming_edges.each { |edge| (requirements[edge.origin.payload] ||= []).unshift(edge.requirement) }
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -252,19 +252,21 @@ module Molinillo
       #   the {#possibility} in conjunction with the current {#state}
       def create_conflict
         vertex = activated.vertex_named(name)
-        requirements = {
-          name_for_explicit_dependency_source => vertex.explicit_requirements,
-          name_for_locking_dependency_source => Array(locked_requirement_named(name)),
-        }
+        locked_requirement = locked_requirement_named(name)
+
+        requirements = {}
+        requirements[name_for_explicit_dependency_source] = vertex.explicit_requirements unless vertex.explicit_requirements.empty?
+        requirements[name_for_locking_dependency_source] = [locked_requirement] if locked_requirement
         vertex.incoming_edges.each { |edge| (requirements[edge.origin.payload] ||= []).unshift(edge.requirement) }
+
         activated_by_name = {}
         activated.each { |v| activated_by_name[v.name] = v.payload if v.payload }
         conflicts[name] = Conflict.new(
           requirement,
-          Hash[requirements.select { |_, r| !r.empty? }],
+          requirements,
           vertex.payload,
           possibility,
-          locked_requirement_named(name),
+          locked_requirement,
           requirement_trees,
           activated_by_name
         )

--- a/lib/molinillo/state.rb
+++ b/lib/molinillo/state.rb
@@ -36,12 +36,14 @@ module Molinillo
       PossibilityState.new(
         name,
         requirements.dup,
-        activated.dup,
+        activated,
         requirement,
         [possibilities.pop],
         depth + 1,
         conflicts.dup
-      )
+      ).tap do |state|
+        state.activated.tag(state)
+      end
     end
   end
 

--- a/spec/dependency_graph/log_spec.rb
+++ b/spec/dependency_graph/log_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Molinillo::DependencyGraph::Log do

--- a/spec/dependency_graph/log_spec.rb
+++ b/spec/dependency_graph/log_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Molinillo::DependencyGraph::Log do
+  shared_examples_for "replay" do |steps|
+    it "replays the log" do
+      copy = Molinillo::DependencyGraph.new
+      graph = Molinillo::DependencyGraph.new.tap {|g| steps.each {|s| s.call(g) }}
+      graph.log.instance_variable_get(:@actions).each {|a| a.up(copy) }
+      expect(copy).to eq(graph)
+    end
+
+    it "can undo to an empty graph" do
+      graph =  Molinillo::DependencyGraph.new.tap {|g| steps.each {|s| s.call(g) }}
+      while graph.log.pop!(graph); end
+      expect(graph).to eq(Molinillo::DependencyGraph.new)
+    end
+  end
+
+  it_behaves_like "replay", []
+  it_behaves_like "replay", [
+    ->(g)  { g.add_child_vertex('Foo', 1, [nil], 4) },
+    ->(g)  { g.add_child_vertex('Bar', 2, ['Foo', nil], 3) },
+    ->(g)  { g.add_child_vertex('Baz', 3, %w(Foo Bar), 2) },
+    ->(g)  { g.add_child_vertex('Foo', 4, [], 1) },
+  ]
+end

--- a/spec/dependency_graph/log_spec.rb
+++ b/spec/dependency_graph/log_spec.rb
@@ -21,9 +21,9 @@ describe Molinillo::DependencyGraph::Log do
 
   it_behaves_like 'replay', []
   it_behaves_like 'replay', [
-    ->(g)  { g.add_child_vertex('Foo', 1, [nil], 4) },
-    ->(g)  { g.add_child_vertex('Bar', 2, ['Foo', nil], 3) },
-    ->(g)  { g.add_child_vertex('Baz', 3, %w(Foo Bar), 2) },
-    ->(g)  { g.add_child_vertex('Foo', 4, [], 1) },
+    proc { |g| g.add_child_vertex('Foo', 1, [nil], 4) },
+    proc { |g| g.add_child_vertex('Bar', 2, ['Foo', nil], 3) },
+    proc { |g| g.add_child_vertex('Baz', 3, %w(Foo Bar), 2) },
+    proc { |g| g.add_child_vertex('Foo', 4, [], 1) },
   ]
 end

--- a/spec/dependency_graph/log_spec.rb
+++ b/spec/dependency_graph/log_spec.rb
@@ -1,23 +1,25 @@
 require 'spec_helper'
 
 describe Molinillo::DependencyGraph::Log do
-  shared_examples_for "replay" do |steps|
-    it "replays the log" do
+  shared_examples_for 'replay' do |steps|
+    it 'replays the log' do
       copy = Molinillo::DependencyGraph.new
-      graph = Molinillo::DependencyGraph.new.tap {|g| steps.each {|s| s.call(g) }}
-      graph.log.instance_variable_get(:@actions).each {|a| a.up(copy) }
+      graph = Molinillo::DependencyGraph.new.tap { |g| steps.each { |s| s.call(g) } }
+      graph.log.each { |a| a.up(copy) }
       expect(copy).to eq(graph)
     end
 
-    it "can undo to an empty graph" do
-      graph =  Molinillo::DependencyGraph.new.tap {|g| steps.each {|s| s.call(g) }}
-      while graph.log.pop!(graph); end
+    it 'can undo to an empty graph' do
+      graph = Molinillo::DependencyGraph.new
+      graph.tag(self)
+      steps.each { |s| s.call(graph) }
+      graph.log.rewind_to(graph, self)
       expect(graph).to eq(Molinillo::DependencyGraph.new)
     end
   end
 
-  it_behaves_like "replay", []
-  it_behaves_like "replay", [
+  it_behaves_like 'replay', []
+  it_behaves_like 'replay', [
     ->(g)  { g.add_child_vertex('Foo', 1, [nil], 4) },
     ->(g)  { g.add_child_vertex('Bar', 2, ['Foo', nil], 3) },
     ->(g)  { g.add_child_vertex('Baz', 3, %w(Foo Bar), 2) },

--- a/spec/dependency_graph_spec.rb
+++ b/spec/dependency_graph_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../spec_helper', __FILE__)
 
 module Molinillo

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../spec_helper', __FILE__)
 
 module Molinillo

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../spec_helper', __FILE__)
 require 'json'
 require 'pathname'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/setup'
 
 # Set up coverage analysis

--- a/spec/spec_helper/index.rb
+++ b/spec/spec_helper/index.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Molinillo
   class TestIndex
     attr_accessor :specs

--- a/spec/spec_helper/specification.rb
+++ b/spec/spec_helper/specification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Molinillo
   class TestSpecification
     attr_accessor :name, :version, :dependencies

--- a/spec/spec_helper/ui.rb
+++ b/spec/spec_helper/ui.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Molinillo
   class TestUI
     include UI

--- a/spec/spec_helper/ui.rb
+++ b/spec/spec_helper/ui.rb
@@ -4,10 +4,10 @@ module Molinillo
 
     def output
       @output ||= if debug?
-        $stderr
-      else
-        File.open('/dev/null', 'w')
-      end
+                    $stderr
+                  else
+                    File.open('/dev/null', 'w')
+                  end
     end
   end
 end

--- a/spec/spec_helper/ui.rb
+++ b/spec/spec_helper/ui.rb
@@ -3,7 +3,11 @@ module Molinillo
     include UI
 
     def output
-      @output ||= File.open('/dev/null', 'w')
+      @output ||= if debug?
+        $stderr
+      else
+        File.open('/dev/null', 'w')
+      end
     end
   end
 end

--- a/spec/state_spec.rb
+++ b/spec/state_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../spec_helper', __FILE__)
 
 module Molinillo


### PR DESCRIPTION
Along with other performance changes made in bundler, this is good for up to a 3x drop in object allocations and a 3x speed up. Probably can optimize further, but I'm just too excited to keep this to myself much longer 🎉 

- [x] CHANGELOG
- [x] Docs
- [x] Performance tuning
- [x] Get rid of metaprogramming

@alloy @indirect 