### PR TITLE
Add support for optional dependencies

### DIFF
--- a/lib/molinillo/delegates/specification_provider.rb
+++ b/lib/molinillo/delegates/specification_provider.rb
@@ -60,6 +60,13 @@ module Molinillo
         end
       end
 
+      # (see Molinillo::SpecificationProvider#optional_dependency?)
+      def optional_dependency?(dependency)
+        with_no_such_dependency_error_handling do
+          specification_provider.optional_dependency?(dependency)
+        end
+      end
+
       private
 
       # Ensures any raised {NoSuchDependencyError} has its

--- a/lib/molinillo/modules/specification_provider.rb
+++ b/lib/molinillo/modules/specification_provider.rb
@@ -96,5 +96,18 @@ module Molinillo
     def allow_missing?(dependency)
       false
     end
+
+    # Returns whether this dependency is considered optional.
+    #
+    # If the only dependencies for a specification name are optional, that
+    # specification will not be activated. If there is a strong dependency as
+    # well, than the requirements imposed by optional dependencies will be taken
+    # into account.
+    #
+    # @param [Object] dependency
+    # @return [Boolean] whether this dependency is optional.
+    def optional_dependency?(dependency)
+      false
+    end
   end
 end

--- a/spec/dependency_graph_spec.rb
+++ b/spec/dependency_graph_spec.rb
@@ -57,7 +57,7 @@ module Molinillo
         @graph.detach_vertex_named(root.name)
         expect(@graph.vertex_named(root.name)).to be_nil
         expect(@graph.vertex_named(child.name)).to eq(child)
-        expect(child.predecessors).to eq([root2])
+        expect(child.predecessors).to contain_exactly(root2)
         expect(@graph.vertices.count).to eq(2)
       end
 

--- a/spec/fuzz_spec.rb
+++ b/spec/fuzz_spec.rb
@@ -13,7 +13,7 @@ describe 'fuzzing' do
       )
     end
   end
-  let(:index) { Molinillo::TestIndex.new('fuzz') }
+  let(:index) { Molinillo::TestIndex.from_fixture('fuzz') }
   let(:ui) { Molinillo::TestUI.new }
   let(:resolver) { Molinillo::Resolver.new(index, ui) }
 

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -11,7 +11,7 @@ module Molinillo
       File.open(fixture_path) do |fixture|
         JSON.load(fixture).tap do |test_case|
           self.name = test_case['name']
-          self.index = TestIndex.new(test_case['index'] || 'awesome')
+          self.index = TestIndex.from_fixture(test_case['index'] || 'awesome')
           self.requested = test_case['requested'].map do |(name, reqs)|
             VersionKit::Dependency.new name, reqs.split(',').map(&:chomp)
           end
@@ -81,8 +81,9 @@ module Molinillo
     end
 
     describe 'in general' do
+      let(:index) { TestIndex.from_fixture('awesome') }
       before do
-        @resolver = described_class.new(TestIndex.new('awesome'), TestUI.new)
+        @resolver = described_class.new(index, TestUI.new)
       end
 
       it 'can resolve a list of 0 requirements' do
@@ -114,7 +115,7 @@ module Molinillo
       end
 
       it 'can resolve when two specs have the same dependencies' do
-        index = BundlerIndex.new('rubygems-2016-09-11')
+        index = BundlerIndex.from_fixture('rubygems-2016-09-11')
         @resolver = described_class.new(index, TestUI.new)
         demands = [
           VersionKit::Dependency.new('chef', '~> 12.1.2'),
@@ -174,7 +175,7 @@ module Molinillo
       end
 
       it 'can resolve when two specs have the same dependencies and swapping happens' do
-        index = BundlerIndex.new('rubygems-2016-10-06')
+        index = BundlerIndex.from_fixture('rubygems-2016-10-06')
         @resolver = described_class.new(index, TestUI.new)
         demands = [
           VersionKit::Dependency.new('avro_turf', '0.6.2'),
@@ -235,7 +236,7 @@ module Molinillo
       end
 
       it 'can unwind when the conflict has a common parent' do
-        index = BundlerIndex.new('rubygems-2016-11-05')
+        index = BundlerIndex.from_fixture('rubygems-2016-11-05')
         @resolver = described_class.new(index, TestUI.new)
         demands = [
           VersionKit::Dependency.new('github-pages', '>= 0'),
@@ -248,7 +249,7 @@ module Molinillo
       end
 
       it 'can resolve when swapping changes transitive dependencies' do
-        index = TestIndex.new('restkit')
+        index = TestIndex.from_fixture('restkit')
         def index.sort_dependencies(dependencies, activated, conflicts)
           dependencies.sort_by do |d|
             [
@@ -288,6 +289,61 @@ module Molinillo
         expect(resolved.map(&:payload).map(&:to_s)).to match_array(expected)
       end
 
+      describe 'optional dependencies' do
+        let(:index) do
+          TestIndex.new(
+            'no_deps' => [
+              TestSpecification.new('name' => 'no_deps', 'version' => '1.0'),
+              TestSpecification.new('name' => 'no_deps', 'version' => '2.0'),
+              TestSpecification.new('name' => 'no_deps', 'version' => '3.0'),
+            ],
+            'strong_dep' => [
+              TestSpecification.new('name' => 'strong_dep', 'version' => '1.0',
+                                    'dependencies' => { 'no_deps' => '< 3' }),
+            ],
+            'weak_dep' => [
+              TestSpecification.new('name' => 'weak_dep', 'version' => '1.0',
+                                    'dependencies' => { 'no_deps' => '< 2 optional' }),
+            ]
+          )
+        end
+
+        let(:no_deps) { VersionKit::Dependency.new('no_deps', '> 1') }
+        let(:weak_dep) { VersionKit::Dependency.new('weak_dep', '>= 0') }
+        let(:strong_dep) { VersionKit::Dependency.new('strong_dep', '>= 0') }
+
+        it 'ignores optional explicit dependencies' do
+          no_deps.optional = true
+          expect(@resolver.resolve([no_deps], DependencyGraph.new).map(&:payload).compact).to be_empty
+        end
+
+        it 'ignores nested optional dependencies' do
+          expect(@resolver.resolve([weak_dep], DependencyGraph.new).map(&:payload).compact.map(&:to_s)).to eq [
+            'weak_dep (1.0.0)',
+            'no_deps (1.0.0)',
+          ]
+        end
+
+        it 'uses nested optional dependencies' do
+          expect(@resolver.resolve([weak_dep, strong_dep], DependencyGraph.new).map(&:payload).compact.map(&:to_s)).
+            to eq [
+              'weak_dep (1.0.0)',
+              'strong_dep (1.0.0)',
+              'no_deps (1.0.0)',
+            ]
+        end
+
+        it 'raises when an optional dependency conflicts' do
+          resolve = proc { @resolver.resolve([weak_dep, no_deps], DependencyGraph.new) }
+          expect(&resolve).to raise_error(Molinillo::VersionConflict, <<-EOS.strip)
+Unable to satisfy the following requirements:
+
+- `no_deps (> 1.0.0)` required by `user-specified dependency`
+- `no_deps (< 2.0.0)` required by `weak_dep (1.0.0)`
+          EOS
+        end
+      end
+
       # Regression test. See: https://github.com/CocoaPods/Molinillo/pull/38
       it 'can resolve when swapping children with successors' do
         swap_child_with_successors_index = Class.new(TestIndex) do
@@ -311,7 +367,7 @@ module Molinillo
           end
         end
 
-        index = swap_child_with_successors_index.new('swap_child_with_successors')
+        index = swap_child_with_successors_index.from_fixture('swap_child_with_successors')
         @resolver = described_class.new(index, TestUI.new)
         demands = [
           VersionKit::Dependency.new('build-essential', '>= 0.0.0'),

--- a/spec/spec_helper/specification.rb
+++ b/spec/spec_helper/specification.rb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
+module VersionKit
+  class Dependency
+    attr_accessor :optional
+    alias optional? optional
+  end
+end
+
 module Molinillo
   class TestSpecification
     attr_accessor :name, :version, :dependencies
     def initialize(hash)
       self.name = hash['name']
       self.version = VersionKit::Version.new(hash['version'])
-      self.dependencies = hash['dependencies'].map do |(name, requirement)|
-        VersionKit::Dependency.new(name, requirement.split(',').map(&:chomp))
+      self.dependencies = hash.fetch('dependencies') { Hash.new }.map do |(name, requirement)|
+        requirements = requirement.split(',').map(&:chomp)
+        optional = requirements.delete('optional')
+        VersionKit::Dependency.new(name, requirements).tap { |d| d.optional = optional }
       end
     end
 


### PR DESCRIPTION
If the only dependencies for a specification name are optional, that specification will not be activated. If there is a strong dependency as well, than the requirements imposed by optional dependencies will be taken into account.

\c @indirect 

@alloy you might find this interesting
