### PR TITLE
Modify backtracking algorithm and remove swapping

### DIFF
--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -203,11 +203,13 @@ module Molinillo
       def state_index_for_unwind
         # TODO maybe move all this somewhere else
         conflict_set = conflicts.map do |key, conflict|
-          # TODO maybe only include conflicting requirements
-          requiring_specs = conflict.requirements.keys.select do |r|
-            r.is_a?(TestSpecification)
+          # TODO what about when no possibilities and no existing spec?
+          spec = conflict.possibility || activated.vertex_named(key)
+          requiring_specs = conflict.requirements.select do |reason, req|
+            reason.is_a?(TestSpecification) &&
+              ! requirement_satisfied_by?(req, activated, spec)
           end
-          [key] + requiring_specs.map(&:name)
+          [key] + requiring_specs.map {|s| s.first.name }
         end.flatten
         conflict_set += conflict_set.map do |conflict_name|
           parents = activated.vertex_named(conflict_name).predecessors

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -216,6 +216,7 @@ module Molinillo
             conflict_set.merge predecessors.map {|p| name_for(p) }
           end
         end
+        debug(depth) { "Conflict set: #{conflict_set.inspect}" }
 
         index = states.size - 2
         until index < 0

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -202,20 +202,10 @@ module Molinillo
       #   case of conflict.
       def state_index_for_unwind
         # TODO maybe move all this somewhere else
-        conflict_set = conflicts.map do |key, conflict|
-          # TODO what about when no possibilities and no existing spec?
-          spec = conflict.possibility || activated.vertex_named(key)
-          requiring_specs = conflict.requirements.select do |reason, req|
-            reason.is_a?(TestSpecification) &&
-              ! requirement_satisfied_by?(req, activated, spec)
-          end
-          [key] + requiring_specs.map {|s| s.first.name }
+        conflict_set = conflicts.keys.map do |key|
+          parents = activated.vertex_named(key).recursive_predecessors
+          [key] + parents.map(&:name)
         end.flatten
-        conflict_set += conflict_set.map do |conflict_name|
-          parents = activated.vertex_named(conflict_name).predecessors
-          parents.first.name unless parents.nil? || parents.empty?
-        end
-        conflict_set = conflict_set.compact.uniq
 
         index = states.size - 2
         until index < 0

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -488,7 +488,12 @@ module Molinillo
       def push_state_for_new_requirements(new_requirements)
         new_requirements -= requirements
         new_requirements = sort_dependencies(new_requirements, activated, conflicts) unless new_requirements.empty?
-        push_state_for_requirements(requirements + new_requirements)
+        full_requirements = (requirements + new_requirements)
+        full_requirements = full_requirements.partition do |r|
+          existing_node = activated.vertex_named(r.name)
+          existing_node && existing_node.payload
+        end.flatten
+        push_state_for_requirements(full_requirements)
       end
 
       # Pushes a new {DependencyState} that encapsulates both existing and new

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -482,13 +482,13 @@ module Molinillo
           parents << parent_index if parents.empty?
         end
 
-        push_state_for_new_requirements(nested_dependencies)
+        push_state_for_new_requirements(requirements + nested_dependencies)
       end
 
       def push_state_for_new_requirements(new_requirements)
-        new_requirements -= requirements
+        new_requirements -= original_requested
         new_requirements = sort_dependencies(new_requirements, activated, conflicts) unless new_requirements.empty?
-        full_requirements = (requirements + new_requirements)
+        full_requirements = (original_requested + new_requirements)
         full_requirements = full_requirements.partition do |r|
           existing_node = activated.vertex_named(r.name)
           existing_node && existing_node.payload

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -192,21 +192,12 @@ module Molinillo
       # @return [Integer] The index to which the resolution should unwind in the
       #   case of conflict.
       def state_index_for_unwind
-        current_requirement = requirement
-        existing_requirement = requirement_for_existing_name(name)
-        index = -1
-        [current_requirement, existing_requirement].each do |r|
-          until r.nil?
-            current_state = find_state_for(r)
-            if state_any?(current_state)
-              current_index = states.index(current_state)
-              index = current_index if current_index > index
-              break
-            end
-            r = parent_of(r)
-          end
+        index = states.size - 2
+        until index < 0
+          current_state = @states[index]
+          return index if state_any?(current_state) && current_state.is_a?(DependencyState)
+          index -= 1
         end
-
         index
       end
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -202,10 +202,15 @@ module Molinillo
       #   case of conflict.
       def state_index_for_unwind
         # TODO maybe move all this somewhere else
-        conflict_set = conflicts.keys.map do |key|
-          parents = activated.vertex_named(key).recursive_predecessors
-          [key] + parents.map(&:name)
-        end.flatten
+        conflict_set = conflicts.map do |key, conflict|
+          parents = conflict.requirements.keys.select do |parent|
+            parent.is_a?(TestSpecification)
+          end.map(&:name)
+          predecessors = parents.map do |name|
+            activated.vertex_named(name).recursive_predecessors.map(&:name)
+          end
+          [key] + parents + predecessors
+        end.flatten.uniq
 
         index = states.size - 2
         until index < 0

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -192,10 +192,17 @@ module Molinillo
       # @return [Integer] The index to which the resolution should unwind in the
       #   case of conflict.
       def state_index_for_unwind
+        conflict_set = conflicts.values.map(&:requirement_trees).flatten.uniq
         index = states.size - 2
         until index < 0
           current_state = @states[index]
-          return index if state_any?(current_state) && current_state.is_a?(DependencyState)
+          if (
+              current_state.is_a?(DependencyState) &&
+              state_any?(current_state) &&
+              conflict_set.include?(current_state.requirement)
+          )
+            return index if state_any?(current_state) && current_state.is_a?(DependencyState)
+          end
           index -= 1
         end
         index

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -208,12 +208,12 @@ module Molinillo
 
           parents = conflict.requirements.keys.select do |parent|
             parent.is_a?(TestSpecification)
-          end.map(&:name)
+          end.map {|p| name_for(p) }
           conflict_set.merge parents
 
           parents.map do |name|
             predecessors = activated.vertex_named(name).recursive_predecessors
-            conflict_set.merge predecessors.map(&:name)
+            conflict_set.merge predecessors.map {|p| name_for(p) }
           end
         end
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -318,7 +318,7 @@ module Molinillo
         existing_spec = existing_node.payload
         if requirement_satisfied_by?(requirement, activated, existing_spec)
           new_requirements = requirements.dup
-          push_state_for_requirements(new_requirements, false)
+          push_state_for_requirements(new_requirements)
         else
           return if attempt_to_swap_possibility
           create_conflict
@@ -446,15 +446,20 @@ module Molinillo
           parents << parent_index if parents.empty?
         end
 
-        push_state_for_requirements(requirements + nested_dependencies, !nested_dependencies.empty?)
+        push_state_for_new_requirements(nested_dependencies)
+      end
+
+      def push_state_for_new_requirements(new_requirements)
+        new_requirements -= requirements
+        new_requirements = sort_dependencies(new_requirements, activated, conflicts) unless new_requirements.empty?
+        push_state_for_requirements(requirements + new_requirements)
       end
 
       # Pushes a new {DependencyState} that encapsulates both existing and new
       # requirements
       # @param [Array] new_requirements
       # @return [void]
-      def push_state_for_requirements(new_requirements, requires_sort = true, new_activated = activated)
-        new_requirements = sort_dependencies(new_requirements.uniq, new_activated, conflicts) if requires_sort
+      def push_state_for_requirements(new_requirements, new_activated = activated)
         new_requirement = new_requirements.shift
         new_name = new_requirement ? name_for(new_requirement) : ''.freeze
         possibilities = new_requirement ? search_for(new_requirement) : []
@@ -475,7 +480,7 @@ module Molinillo
       def handle_missing_or_push_dependency_state(state)
         if state.requirement && state.possibilities.empty? && allow_missing?(state.requirement)
           state.activated.detach_vertex_named(state.name)
-          push_state_for_requirements(state.requirements.dup, false, state.activated)
+          push_state_for_requirements(state.requirements.dup, state.activated)
         else
           states.push(state).tap { activated.tag(state) }
         end

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -508,10 +508,6 @@ module Molinillo
         new_requirement = new_requirements.shift
         new_name = new_requirement ? name_for(new_requirement) : ''.freeze
         possibilities = new_requirement ? search_for(new_requirement) : []
-        existing_node = activated.vertex_named(new_name)
-        if existing_node && existing_node.payload
-          possibilities = possibilities & [existing_node.payload]
-        end
         handle_missing_or_push_dependency_state DependencyState.new(
           new_name, new_requirements, new_activated,
           new_requirement, possibilities, depth, conflicts.dup

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -485,15 +485,19 @@ module Molinillo
         push_state_for_new_requirements(requirements + nested_dependencies)
       end
 
-      def push_state_for_new_requirements(new_requirements)
-        new_requirements -= original_requested
-        new_requirements = sort_dependencies(new_requirements, activated, conflicts) unless new_requirements.empty?
-        full_requirements = (original_requested + new_requirements)
-        full_requirements = full_requirements.partition do |r|
+      def push_state_for_new_requirements(requirements)
+        requirements = sort_dependencies(requirements, activated, conflicts)
+        idx = 0
+        requirements.sort_by! do |r|
+          idx += 1
           existing_node = activated.vertex_named(r.name)
-          existing_node && existing_node.payload
-        end.flatten
-        push_state_for_requirements(full_requirements)
+          [
+            original_requested.include?(r) ? 0 : 1,
+            existing_node && existing_node.payload ? 0 : 1,
+            idx
+          ]
+        end
+        push_state_for_requirements(requirements)
       end
 
       # Pushes a new {DependencyState} that encapsulates both existing and new

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -340,7 +340,7 @@ module Molinillo
         existing_spec = existing_node.payload
         if requirement_satisfied_by?(requirement, activated, existing_spec)
           new_requirements = requirements.dup
-          push_state_for_requirements(new_requirements)
+          push_state_for_requirements(new_requirements, false)
         else
           return if attempt_to_swap_possibility
           create_conflict
@@ -468,20 +468,15 @@ module Molinillo
           parents << parent_index if parents.empty?
         end
 
-        push_state_for_new_requirements(nested_dependencies)
-      end
-
-      def push_state_for_new_requirements(new_requirements)
-        new_requirements -= requirements
-        new_requirements = sort_dependencies(new_requirements, activated, conflicts) unless new_requirements.empty?
-        push_state_for_requirements(requirements + new_requirements)
+        push_state_for_requirements(requirements + nested_dependencies, !nested_dependencies.empty?)
       end
 
       # Pushes a new {DependencyState} that encapsulates both existing and new
       # requirements
       # @param [Array] new_requirements
       # @return [void]
-      def push_state_for_requirements(new_requirements, new_activated = activated)
+      def push_state_for_requirements(new_requirements, requires_sort = true, new_activated = activated)
+        new_requirements = sort_dependencies(new_requirements.uniq, new_activated, conflicts) if requires_sort
         new_requirement = new_requirements.shift
         new_name = new_requirement ? name_for(new_requirement) : ''.freeze
         possibilities = new_requirement ? search_for(new_requirement) : []
@@ -506,7 +501,7 @@ module Molinillo
       def handle_missing_or_push_dependency_state(state)
         if state.requirement && state.possibilities.empty? && allow_missing?(state.requirement)
           state.activated.detach_vertex_named(state.name)
-          push_state_for_requirements(state.requirements.dup, state.activated)
+          push_state_for_requirements(state.requirements.dup, false, state.activated)
         else
           states.push(state).tap { activated.tag(state) }
         end

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -470,6 +470,10 @@ module Molinillo
         new_requirement = new_requirements.shift
         new_name = new_requirement ? name_for(new_requirement) : ''.freeze
         possibilities = new_requirement ? search_for(new_requirement) : []
+        existing_node = activated.vertex_named(new_name)
+        if existing_node && existing_node.payload
+          possibilities = possibilities & [existing_node.payload]
+        end
         handle_missing_or_push_dependency_state DependencyState.new(
           new_name, new_requirements, new_activated,
           new_requirement, possibilities, depth, conflicts.dup

--- a/lib/molinillo/state.rb
+++ b/lib/molinillo/state.rb
@@ -15,7 +15,8 @@ module Molinillo
     :requirement,
     :possibilities,
     :depth,
-    :conflicts
+    :conflicts,
+    :conflict_set
   )
 
   class ResolutionState

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -84,14 +84,30 @@ module Molinillo
     end
 
     def ignore?(index_class)
-      if index_class == BerkshelfIndex &&
-          name == 'can resolve when two specs have the same dependencies and swapping happens' &&
+      if name == 'can resolve when two specs have the same dependencies and swapping happens'
+        if index_class == BerkshelfIndex &&
           Gem.ruby_version < Gem::Version.new('2.3')
 
-        # That index doesn't do a great job sorting, and segiddins has been
-        # unable to get the test passing with the bad sort (on Ruby < 2.3)
-        # without breaking other specs
-        return true
+          # That index doesn't do a great job sorting, and segiddins has been
+          # unable to get the test passing with the bad sort (on Ruby < 2.3)
+          # without breaking other specs
+          return true
+        end
+
+        # These indexes don't sort to minimize conflicts, so a deep dependency
+        # tree is too slow with them.
+        if index_class == TestIndex || index_class == ReverseBundlerIndex
+          return true
+        end
+
+        #TODO figure out what to do with this
+        return true if index_class == BerkshelfIndex
+      end
+
+      if name == 'deep conflicts with duplicate dependencies'
+        return true if index_class == ReverseBundlerIndex
+        #TODO figure out what to do with this
+        return true if index_class == BerkshelfIndex
       end
 
       false


### PR DESCRIPTION
# The Good

This pulls in fixes for several issues I've uncovered in the process, like #63 and https://github.com/CocoaPods/Resolver-Integration-Specs/pull/10.

It also makes the backtracking algorithm predictable, so that you can assume certain guarantees about the resolution you'll get based on the order of items you feed in via `sort_dependencies` and `search_for`. This was the original reason I started looking into this.

# The Bad

Performance is worse right now. The integration specs see about a 3-4X slowdown. I haven't gone deep on profiling, so I don't know if there are some easy Ruby optimizations that could speed this up or if this is just the reality of removing swapping. There may also ways to optimize the algorithm for common scenarios, though I picked off a couple of the most obvious ones.

Performance gets very, very bad if `sort_dependencies` doesn't do some work to optimize for conflict-heavy packages. The Bundler and CocoaPods indexes are fine here. A couple of the test indexes are slow because they sort funny (not such a big deal), but the Berkshelf index is also deeply slow due to this (probably a bigger deal).

# The Ugly

To guarantee the "best" outcomes (i.e. that your original dependencies resolve to the highest valid versions), `sort_dependencies` needs to ensure that the original dependencies are sorted ahead of everything else on the list. The current indexes don't do this. Right now I have some code in Molinillo as a workaround, but I think that's probably not really the appropriate place to handle it—probably we should trust the inputs to know what they're doing. So this change would require updates to the packages that use Molinillo to avoid them running into issues.