### PR TITLE
Rewind to correct state during resolution for mutually required dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@
 
 ##### Bug Fixes
 
-* None.  
+* Rewind to the nearest requirement for an unsatisfied spec, rather than the
+  first requirement. Fixes a non-idempotent lockfile generation issue, and some
+  erroneous version conflict errors.
+  [Grey Baker](https://github.com/greysteil)
+  [bundler/bundler#5569](https://github.com/bundler/bundler#5569)
+  [bundler/bundler#5633](https://github.com/bundler/bundler#5633)
 
 
 ## 0.5.7 (2017-03-03)

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -223,7 +223,7 @@ module Molinillo
       #   with the given name being activated.
       def requirement_for_existing_name(name)
         return nil unless activated.vertex_named(name).payload
-        states.find { |s| s.name == name }.requirement
+        states.select { |s| s.name == name && s.is_a?(DependencyState) }[-2].requirement
       end
 
       # @return [ResolutionState] the state whose `requirement` is the given

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -94,6 +94,11 @@ module Molinillo
         return true
       end
 
+      if index_class == BerkshelfIndex && name == 'resolves a conflict which requires non-trivial unwinding'
+        # As above, except here the index is a large, and breaks on all Rubies
+        return true
+      end
+
       false
     end
 


### PR DESCRIPTION
When the resolver encounters a conflict, it looks to unwind to whatever requirement created the unsatisfied spec, from where it will check whether there are more potential specs to be tried. To do so, we wish to traverse up the state tree (from the end) until we find the offending state.

Previously, the logic for doing so made a simplifying assumption: that there would only be one state in the tree specifying a requirement for the unsatisfied spec. Unfortunately that's not always the case - it's possible, though rare, to have a state tree with multiple states making requirements on a dependency version. When this happens, our simplifying logic is wrong and causes the rewind to go back too, far, potentially missing valid resolutions. This can cause [non-idempotent lockfiles](https://github.com/bundler/bundler/issues/5633) (as the existing resolution is wrongly discarded each time) or [erroneous version conflicts](https://github.com/bundler/bundler/issues/5569) (as no resolution is found when there actually is one).

The fix is really simple: rather than traverse up the tree from the start, traverse down it from the end. Note that we have to discard the very end node, which is our current (unsatisfied) spec.

Fixes https://github.com/bundler/bundler/issues/5569.
Fixes https://github.com/bundler/bundler/issues/5633.