### PR TITLE
Respect locked dependencies at possibility creation time

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ This stack-based approach is used because backtracking (also known as *unwinding
 8. Process the topmost state on the stack
 9. If there's a possibility for the state, `attempt_to_activate` it (jump to #11)
 10. If there's no possibility, `create_conflict` if the state is a `PossibilityState`, and then `unwind_for_conflict` until there's a `DependencyState` with a `possibility` atop the stack
-11. Check if there is an existing node in the `activated` dependency graph with the name of the current `requirement`
+11. Check if there is an existing vertex in the `activated` dependency graph with the name of the current `requirement`
 12. If so, `attempt_to_activate_existing_spec` (jump to #14). If not, `attempt_to_activate_new_spec`
 13. Check if there is a `locked` dependency with the current dependency's name. If there is, verify that both the locked dependency and the current `requirement` are satisfied with the current `possibility`. If either is not satisfied, `create_conflict` and `unwind_for_conflict`
 14. In either case, if the requirement is satisfied by the existing spec (if existing), or the new spec (if not), a new state is pushed with the now-activated `possibility`'s own dependencies. Go to #5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ##### Enhancements
 
-* None.  
+* Check for locked requirements when generating a new state's possibilities
+  array, and reduce possibilities set accordingly. Reduces scope for erroneous
+  VersionConflict errors.
+  [Grey Baker](https://github.com/greysteil)
+  [#67](https://github.com/CocoaPods/Molinillo/pull/67)
 
 ##### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     ast (2.2.0)
     codeclimate-test-reporter (0.4.1)
       simplecov (>= 0.7.1, < 1.0.0)
-    coderay (1.1.0)
+    coderay (1.1.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
     ffi (1.9.10)
@@ -36,7 +36,7 @@ GEM
     parser (2.3.0.6)
       ast (~> 2.2)
     powerpack (0.1.1)
-    pry (0.10.3)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -96,4 +96,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.14.0
+   1.15.1

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -147,8 +147,8 @@ module Molinillo
       vertex = add_vertex(name, payload, root)
       vertex.explicit_requirements << requirement if root
       parent_names.each do |parent_name|
-        parent_node = vertex_named(parent_name)
-        add_edge(parent_node, vertex, requirement)
+        parent_vertex = vertex_named(parent_name)
+        add_edge(parent_vertex, vertex, requirement)
       end
       vertex
     end

--- a/lib/molinillo/errors.rb
+++ b/lib/molinillo/errors.rb
@@ -41,11 +41,11 @@ module Molinillo
     attr_reader :dependencies
 
     # Initializes a new error with the given circular vertices.
-    # @param [Array<DependencyGraph::Vertex>] nodes the nodes in the dependency
+    # @param [Array<DependencyGraph::Vertex>] vertices the vertices in the dependency
     #   that caused the error
-    def initialize(nodes)
-      super "There is a circular dependency between #{nodes.map(&:name).join(' and ')}"
-      @dependencies = nodes.map(&:payload).to_set
+    def initialize(vertices)
+      super "There is a circular dependency between #{vertices.map(&:name).join(' and ')}"
+      @dependencies = vertices.map(&:payload).to_set
     end
   end
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -311,10 +311,10 @@ module Molinillo
       # @return [void]
       def attempt_to_activate
         debug(depth) { 'Attempting to activate ' + possibility.to_s }
-        existing_node = activated.vertex_named(name)
-        if existing_node.payload
-          debug(depth) { "Found existing spec (#{existing_node.payload})" }
-          attempt_to_activate_existing_spec(existing_node)
+        existing_vertex = activated.vertex_named(name)
+        if existing_vertex.payload
+          debug(depth) { "Found existing spec (#{existing_vertex.payload})" }
+          attempt_to_activate_existing_spec(existing_vertex)
         else
           attempt_to_activate_new_spec
         end
@@ -323,15 +323,15 @@ module Molinillo
       # Attempts to activate the current {#possibility} (given that it has
       # already been activated)
       # @return [void]
-      def attempt_to_activate_existing_spec(existing_node)
-        existing_spec = existing_node.payload
+      def attempt_to_activate_existing_spec(existing_vertex)
+        existing_spec = existing_vertex.payload
         if requirement_satisfied_by?(requirement, activated, existing_spec)
           new_requirements = requirements.dup
           push_state_for_requirements(new_requirements, false)
         else
           return if attempt_to_swap_possibility
           create_conflict
-          debug(depth) { "Unsatisfied by existing spec (#{existing_node.payload})" }
+          debug(depth) { "Unsatisfied by existing spec (#{existing_vertex.payload})" }
           unwind_for_conflict
         end
       end
@@ -477,7 +477,7 @@ module Molinillo
       # If the {#specification_provider} says to
       # {SpecificationProvider#allow_missing?} that particular requirement, and
       # there are no possibilities for that requirement, then `state` is not
-      # pushed, and the node in {#activated} is removed, and we continue
+      # pushed, and the vertex in {#activated} is removed, and we continue
       # resolving the remaining requirements.
       # @param [DependencyState] state
       # @return [void]

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -158,7 +158,10 @@ module Molinillo
       # @return [DependencyState] the initial state for the resolution
       def initial_state
         graph = DependencyGraph.new.tap do |dg|
-          original_requested.each { |r| dg.add_vertex(name_for(r), nil, true).tap { |v| v.explicit_requirements << r } }
+          original_requested.each do |requested|
+            vertex = dg.add_vertex(name_for(requested), nil, true)
+            vertex.explicit_requirements << requested
+          end
           dg.tag(:initial_state)
         end
 
@@ -169,7 +172,7 @@ module Molinillo
           requirements,
           graph,
           initial_requirement,
-          initial_requirement && search_for(initial_requirement),
+          possibilities_for_requirement(initial_requirement, graph),
           0,
           {}
         )
@@ -314,7 +317,7 @@ module Molinillo
         existing_vertex = activated.vertex_named(name)
         if existing_vertex.payload
           debug(depth) { "Found existing spec (#{existing_vertex.payload})" }
-          attempt_to_activate_existing_spec(existing_vertex)
+          attempt_to_activate_existing_spec(existing_vertex.payload)
         else
           attempt_to_activate_new_spec
         end
@@ -323,15 +326,14 @@ module Molinillo
       # Attempts to activate the current {#possibility} (given that it has
       # already been activated)
       # @return [void]
-      def attempt_to_activate_existing_spec(existing_vertex)
-        existing_spec = existing_vertex.payload
-        if requirement_satisfied_by?(requirement, activated, existing_spec)
+      def attempt_to_activate_existing_spec(spec)
+        if requirement_satisfied_by?(requirement, activated, spec)
           new_requirements = requirements.dup
           push_state_for_requirements(new_requirements, false)
         else
           return if attempt_to_swap_possibility
           create_conflict
-          debug(depth) { "Unsatisfied by existing spec (#{existing_vertex.payload})" }
+          debug(depth) { "Unsatisfied by existing spec (#{spec})" }
           unwind_for_conflict
         end
       end
@@ -466,11 +468,29 @@ module Molinillo
         new_requirements = sort_dependencies(new_requirements.uniq, new_activated, conflicts) if requires_sort
         new_requirement = new_requirements.shift
         new_name = new_requirement ? name_for(new_requirement) : ''.freeze
-        possibilities = new_requirement ? search_for(new_requirement) : []
+        possibilities = possibilities_for_requirement(new_requirement)
         handle_missing_or_push_dependency_state DependencyState.new(
           new_name, new_requirements, new_activated,
           new_requirement, possibilities, depth, conflicts.dup
         )
+      end
+
+      # Checks a proposed requirement with any existing locked requirement
+      # before generating an array of possibilities for it.
+      # @param [Object] the proposed requirement
+      # @return [Array] possibilities
+      def possibilities_for_requirement(requirement, activated = self.activated)
+        return [] unless requirement
+        locked_requirement = locked_requirement_named(name_for(requirement))
+        all_possibilities = search_for(requirement)
+        return all_possibilities unless locked_requirement
+
+        # Longwinded way to build a possibilities array with either the locked
+        # requirement or nothing in it. Required, since the API for
+        # locked_requirement isn't guaranteed.
+        all_possibilities.select do |possibility|
+          requirement_satisfied_by?(locked_requirement, activated, possibility)
+        end
       end
 
       # Pushes a new {DependencyState}.

--- a/spec/dependency_graph_spec.rb
+++ b/spec/dependency_graph_spec.rb
@@ -29,7 +29,7 @@ module Molinillo
       end
     end
 
-    describe 'detaching a node' do
+    describe 'detaching a vertex' do
       before do
         @graph = described_class.new
       end

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -19,15 +19,15 @@ module Molinillo
             name = hash['name']
             version = Gem::Version.new(hash['version'])
             dependency = index.specs[name].find { |s| s.version == version }
-            node = if parent
-                     graph.add_vertex(name, dependency).tap do |v|
-                       graph.add_edge(parent, v, dependency)
+            vertex = if parent
+                       graph.add_vertex(name, dependency).tap do |v|
+                         graph.add_edge(parent, v, dependency)
+                       end
+                     else
+                       graph.add_vertex(name, dependency, true)
                      end
-                   else
-                     graph.add_vertex(name, dependency, true)
-                   end
             hash['dependencies'].each do |dep|
-              add_dependencies_to_graph.call(graph, node, dep)
+              add_dependencies_to_graph.call(graph, vertex, dep)
             end
           end
           self.result = test_case['resolved'].reduce(DependencyGraph.new) do |graph, r|
@@ -161,7 +161,7 @@ module Molinillo
         expect(resolved.map(&:payload).map(&:to_s)).to eq(['actionpack (1.2.3)'])
       end
 
-      it 'only cleans up orphaned nodes after swapping' do
+      it 'only cleans up orphaned vertices after swapping' do
         index = TestIndex.new(
           'a' => [
             TestSpecification.new('name' => 'a', 'version' => '1.0.0', 'dependencies' => { 'z' => '= 2.0.0' }),


### PR DESCRIPTION
Some minor tweaks after (unsuccessfully) trying to debug a resolver issue:
- Cut out some needless possibility attempts, in order to gain a modest efficiency improvement
- Bump `pry` so it doesn't display hundreds of deprecation warnings when used
- Rename `node` to `vertex` everywhere. They're synonymous, but using one improves clarity

~~The removed possibilities are the cases where an existing spec has already been activated for a requirement. In this case, there's no need to iterate through that requirement's possibilities - all but the existing spec would be ignored anyway. For the `BundlerIndex`, on the integration test `can resolve when two specs have the same dependencies`, this reduces the number of steps to resolution from 1390 to 798, and the time taken to do the resolution 100 times from 31.7 seconds to 21.0 seconds. ⚡️~~

The removed possibilities are the cases where a locked requirement is in place for a spec - there's no need to consider any versions of this spec except the locked version. Removing these possibilities doesn't yield much of a speedup (it's statistically insignificant in the tests I've done), but it does sometimes fix inaccurate `VersionConflict` errors - https://github.com/CocoaPods/Resolver-Integration-Specs/pull/11/ now passes on all indexes except `ReverseBundlerIndex`. That change will be due to having better initial conditions for the resolution (i.e., starting with the locked dependency versions) - there's still a bug in rewinding present.