### PR TITLE
Consider previous conflicts when determining the state to unwind to

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
 Style/TrailingCommaInArguments:
   Enabled: false
 
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
 RaiseArgs:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInLiteral:
   Enabled: false
 
+Style/EmptyElse:
+  EnforcedStyle: empty
+
 RaiseArgs:
   Enabled: false
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,8 +52,8 @@ conflict we:
 
 1. Discard any requirements that aren't "binding" - that is, any that are
 unnecessary to cause the current conflict. We do this by looping over through
-the requirements in revers order to how they were added, removing each one if it
-is no necessary
+the requirements in reverse order to how they were added, removing each one if
+it is not necessary
 2. Loop through the array of binding requirements, looking for the highest index
 state that has possibilities that may still lead to a resolution. For each
 requirement:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,9 @@ This stack-based approach is used because backtracking (also known as *unwinding
 7. If the current state is a `DependencyState`, we have it pop off a `PossibilityState` that encapsulates a `PossibilitySet` for that dependency
 8. Process the topmost state on the stack
 9. If there is a non-empty `PossibilitySet` for the state, `attempt_to_activate` it (jump to #11)
-10. If there is no non-empty `PossibilitySet` for the state, `create_conflict` if the state is a `PossibilityState`, and then `unwind_for_conflict` until there's a `DependencyState` with a non-empty `PossibilitySet` atop the stack
+10. If there is no non-empty `PossibilitySet` for the state, `create_conflict` if the state is a `PossibilityState`, and then `unwind_for_conflict`
+  - `create_conflict` builds a `Conflict` object, with details of all of the requirements for the given dependency, and adds it to a hash of conflicts stored on the `state`, indexed by the name of the dependency
+  - `unwind_for_conflict` loops through all the conflicts on the `state`, looking for a state it can rewind to that might avoid that conflict. If no such state exists, it raises a VersionConflict error. Otherwise, it takes the most recent state with a chance to avoid the current conflicts and rewinds to it (go to #6)
 11. Check if there is an existing vertex in the `activated` dependency graph for the dependency this state's `requirement` relates to
 12. If there is no existing vertex in the `activated` dependency graph for the dependency this state's `requirement` relates to, `activate_new_spec`. This creates a new vertex in the `activated` dependency graph, with it's payload set to the possibility's `PossibilitySet`. It also pushes a new `DependencyState`, with the now-activated `PossibilitySet`'s own dependencies. Go to #6
 13. If there is an existing, `activated` vertex for the dependency, `attempt_to_filter_existing_spec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 ##### Enhancements
 
-* Consider previous conflicts when determining the state to unwind to. If a
-  previous conflict, for a different dependency, is the reason we ended up with
-  the current conflict, then unwinding to a state that would not have caused
-  that conflict could prevent the current one, too.
-  [Grey Baker](https://github.com/greysteil)
-  [#72](https://github.com/CocoaPods/Molinillo/pull/72)
-
 * Speed up dependency resolution by considering multiple possible versions of a
   dependency at once, grouped its sub-dependencies. Groups are then filtered as
   additional requirements are introduced. If a group's sub-dependencies cause
@@ -28,7 +21,19 @@
 
 ##### Bug Fixes
 
-* None.  
+* Consider additional (binding) requirements that caused a conflict when
+  determining which state to unwind to. Previously, in some cases Molinillo
+  would erroneously throw a VersionConflict error if multiple requirements
+  combined to cause a conflict.
+  [Grey Baker](https://github.com/greysteil)
+  [#72](https://github.com/CocoaPods/Molinillo/pull/72) 
+
+* Consider previous conflicts when determining the state to unwind to. If a
+  previous conflict, for a different dependency, is the reason we ended up with
+  the current conflict, then unwinding to a state that would not have caused
+  that conflict could prevent the current one, too.
+  [Grey Baker](https://github.com/greysteil)
+  [#72](https://github.com/CocoaPods/Molinillo/pull/72)
 
 
 ## 0.5.7 (2017-03-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ##### Enhancements
 
+* Consider previous conflicts when determining the state to unwind to. If a
+  previous conflict, for a different dependency, is the reason we ended up with
+  the current conflict, then unwinding to a state that would not have caused
+  that conflict could prevent the current one, too.
+  [Grey Baker](https://github.com/greysteil)
+  [#72](https://github.com/CocoaPods/Molinillo/pull/72)
+
 * Speed up dependency resolution by considering multiple possible versions of a
   dependency at once, grouped its sub-dependencies. Groups are then filtered as
   additional requirements are introduced. If a group's sub-dependencies cause

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -227,18 +227,21 @@ module Molinillo
       # @return [Integer] The index to which the resolution should unwind in the
       #   case of conflict.
       def state_index_for_unwind
-        current_requirement = requirement
-        existing_requirement = requirement_for_existing_name(name)
         index = -1
-        [current_requirement, existing_requirement].each do |r|
-          until r.nil?
-            current_state = find_state_for(r)
-            if state_any?(current_state)
-              current_index = states.index(current_state)
-              index = current_index if current_index > index
-              break
+        conflicts.each do |dependency_name, conflict|
+          next unless activated.vertex_named(dependency_name)
+          current_requirement = conflict.requirement
+          existing_requirement = requirement_for_existing_name(dependency_name)
+          [current_requirement, existing_requirement].each do |r|
+            until r.nil?
+              current_state = find_state_for(r)
+              if state_any?(current_state)
+                current_index = states.index(current_state)
+                index = current_index if current_index > index
+                break
+              end
+              r = parent_of(r)
             end
-            r = parent_of(r)
           end
         end
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -246,17 +246,16 @@ module Molinillo
           # requirements to the conflict - doing so would only result in us
           # encountering the same conflict again, possibly after processing many
           # wasted steps.
-          requirements_to_attempt_to_relax = [
-            initial_requirement_for_name(dependency_name),
-            *binding_requirements_for_conflict(conflict)
-          ].compact.uniq
+          requirements_to_attempt_to_relax = binding_requirements_for_conflict(conflict).
+                                             unshift(initial_requirement_for_name(dependency_name)).
+                                             tap(&:compact!).tap(&:uniq!)
 
           requirements_to_attempt_to_relax.each do |r|
             until r.nil?
               return index if index == maximal_index
               current_state = find_state_for(r)
               filter_possibilities_for_conflict(current_state, conflict)
-              if current_state && current_state.possibilities.any?
+              if current_state && !current_state.possibilities.empty?
                 current_index = states.index(current_state)
                 index = current_index if current_index > index
                 break

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -248,7 +248,7 @@ module Molinillo
           # wasted steps.
           requirements_to_attempt_to_relax = binding_requirements_for_conflict(conflict).
                                              unshift(initial_requirement_for_name(dependency_name)).
-                                             tap(&:compact!).tap(&:uniq!)
+                                             tap(&:uniq!)
 
           requirements_to_attempt_to_relax.each do |r|
             until r.nil?

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -254,8 +254,7 @@ module Molinillo
             until r.nil?
               return index if index == maximal_index
               current_state = find_state_for(r)
-              filter_possibilities_for_conflict(current_state, conflict)
-              if current_state && !current_state.possibilities.empty?
+              if conflict_fixing_possibilities?(current_state, conflict)
                 current_index = states.index(current_state)
                 index = current_index if current_index > index
                 break
@@ -277,23 +276,22 @@ module Molinillo
         states.find { |s| s.name == name }.requirement
       end
 
-      # Filter's a state's possibilities to remove any that do not fix the
-      # current conflict
       # @param [DependencyState] state
       # @param [Conflict] conflict
-      # @return [void]
-      def filter_possibilities_for_conflict(state, conflict)
-        return unless state && !state.possibilities.empty?
+      # @return [Boolean] whether or not the given state has any possibilities
+      #    that could fix or avoid the given conflict
+      def conflict_fixing_possibilities?(state, conflict)
+        return false unless state && !state.possibilities.empty?
 
         # If the state introduces a requirement that caused the conflict, we
         # need to check the possibilities fix the conflict. Otherwise we can
         # return true (optimistically)
-        return unless name_for(conflict.requirement) == state.name
+        return true unless name_for(conflict.requirement) == state.name
 
         all_requirements = conflict.requirements.values.flatten(1).uniq
 
-        state.possibilities.reject! do |possibility_set|
-          possibility_set.possibilities.none? do |poss|
+        state.possibilities.any? do |possibility_set|
+          possibility_set.possibilities.any? do |poss|
             activated.tag(:swap)
             name = name_for(poss)
             activated.set_payload(name, poss) if activated.vertex_named(name)

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -228,12 +228,12 @@ module Molinillo
       #   case of conflict.
       def state_index_for_unwind
         index = -1
+        maximal_index = states.size - 2
         conflicts.each do |dependency_name, conflict|
           next unless activated.vertex_named(dependency_name)
-          current_requirement = conflict.requirement
-          existing_requirement = requirement_for_existing_name(dependency_name)
-          [current_requirement, existing_requirement].each do |r|
+          conflict.requirements.values.flatten(1).uniq.each do |r|
             until r.nil?
+              return index if index == maximal_index
               current_state = find_state_for(r)
               if state_any?(current_state)
                 current_index = states.index(current_state)
@@ -255,13 +255,6 @@ module Molinillo
         return unless index = @parents_of[requirement].last
         return unless parent_state = @states[index]
         parent_state.requirement
-      end
-
-      # @return [Object] the requirement that led to a version of a possibility
-      #   with the given name being activated.
-      def requirement_for_existing_name(name)
-        return nil unless activated.vertex_named(name).payload
-        states.find { |s| s.name == name }.requirement
       end
 
       # @return [ResolutionState] the state whose `requirement` is the given


### PR DESCRIPTION
If a previous conflict, for a different dependency, is the reason we ended up with the current conflict, then unwinding to a state that would not have caused that conflict could prevent the current one, too.

Makes https://github.com/CocoaPods/Resolver-Integration-Specs/pull/13 pass.