### PR TITLE
Re-enable all the indexes / specs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,13 +69,10 @@ the previous unwinds that have determined our current state.
 different, smaller unwind was chosen instead):
   - Ignore any previously unused unwinds that would now unwind further than the
   highest index found in (1), if any
-  - For the remaining unused unwind, check whether the unwind has a chance of
+  - For the remaining unused unwinds, check whether the unwind has a chance of
   preventing us encountering the current conflict. For this to be the case, the
-  unwind's requirement tree must overlap with an element of one of the
-  requirement trees for the current conflict
-    - TODO: I _think_ we can make this much stronger: the state that was rewound
-    to instead of opting for this unwind must be in the requirement tree for the
-    current conflict
+  unwind must have been rejected in favour of an unwind to one of the states in
+  the current conflict's requirement tree
   - If any such unwinds exist, use the one with the highest index (smallest
   unwind) instead of the one found in (1)
 3a. If no possible unwind was found in (1) and (2), raise a VersionConflict
@@ -88,6 +85,8 @@ possibilities that will certainly result in *all* of those conflicts can be
 filtered out as having no chance of resolution
 4. Update the list of unused unwinds:
   - Add all possible unwinds for the current conflict
+  - Update the `requirements_unwound_to_instead` attribute on any considered
+  unwind that was only rejected because it had a lower index than the chosen one
   - Remove all unwinds to a state greater than or equal to the chosen unwind
 5. Go to #6 in the main loop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ##### Enhancements
 
 * Speed up dependency resolution by considering multiple possible versions of a
-  dependency at once, grouped its sub-dependencies. Groups are then filtered as
+  dependency at once, grouped by sub-dependencies. Groups are then filtered as
   additional requirements are introduced. If a group's sub-dependencies cause
   conflicts the entire group can be discarded, which reduces the number of
   possibilities that have to be tested to find a resolution.
@@ -24,6 +24,14 @@
   [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
+
+* Improve unwinding by considering previous conflicts for the same dependency
+  when deciding which state to unwind to. Previously, prior conflicts were
+  stored in a hash indexed by their name, with only the most recent conflict
+  stored for each dependency. With this fix, Molinillo can resolve anything
+  that's thrown at it. 🎉
+  [Grey Baker](https://github.com/greysteil)
+  [#73](https://github.com/CocoaPods/Molinillo/pull/73)
 
 * Only raise CircularDependency errors if they prevent resolution.
   [Ian Young](https://github.com/iangreenleaf)

--- a/lib/molinillo/delegates/resolution_state.rb
+++ b/lib/molinillo/delegates/resolution_state.rb
@@ -46,6 +46,12 @@ module Molinillo
         current_state = state || Molinillo::ResolutionState.empty
         current_state.conflicts
       end
+
+      # (see Molinillo::ResolutionState#unused_unwind_options)
+      def unused_unwind_options
+        current_state = state || Molinillo::ResolutionState.empty
+        current_state.unused_unwind_options
+      end
     end
   end
 end

--- a/lib/molinillo/state.rb
+++ b/lib/molinillo/state.rb
@@ -8,7 +8,8 @@ module Molinillo
   # @attr [Object] requirement the current requirement
   # @attr [Object] possibilities the possibilities to satisfy the current requirement
   # @attr [Integer] depth the depth of the resolution
-  # @attr [Set<Object>] conflicts unresolved conflicts
+  # @attr [Hash] conflicts unresolved conflicts, indexed by dependency name
+  # @attr [Array<UnwindDetails>] unused_unwind_options unwinds for previous conflicts that weren't explored
   ResolutionState = Struct.new(
     :name,
     :requirements,
@@ -16,14 +17,15 @@ module Molinillo
     :requirement,
     :possibilities,
     :depth,
-    :conflicts
+    :conflicts,
+    :unused_unwind_options
   )
 
   class ResolutionState
     # Returns an empty resolution state
     # @return [ResolutionState] an empty state
     def self.empty
-      new(nil, [], DependencyGraph.new, nil, nil, 0, Set.new)
+      new(nil, [], DependencyGraph.new, nil, nil, 0, {}, [])
     end
   end
 
@@ -41,7 +43,8 @@ module Molinillo
         requirement,
         [possibilities.pop],
         depth + 1,
-        conflicts.dup
+        conflicts.dup,
+        unused_unwind_options.dup
       ).tap do |state|
         state.activated.tag(state)
       end

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -80,8 +80,6 @@ module Molinillo
 
       context.instance_eval do
         it test_case.name do
-          skip 'does not yet reliably pass' if test_case.ignore?(index_class)
-
           if test_case.conflicts.any?
             expect { test_case.resolve(index_class) }.to raise_error do |error|
               expect(error).to be_a(ResolverError)
@@ -105,19 +103,6 @@ module Molinillo
           end
         end
       end
-    end
-
-    def ignore?(index_class)
-      if [BerkshelfIndex, ReverseBundlerIndex, RandomSortIndex].include?(index_class) &&
-          name == 'can resolve when two specs have the same dependencies and swapping happens'
-
-        # These indexes don't do a great job sorting, and segiddins has been
-        # unable to get the test passing with the bad sort without breaking
-        # other specs
-        return true
-      end
-
-      false
     end
 
     def self.save!(path, name, index, requirements, resolved)

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -80,6 +80,8 @@ module Molinillo
 
       context.instance_eval do
         it test_case.name do
+          skip 'does not yet reliably pass' if test_case.ignore?(index_class)
+
           if test_case.conflicts.any?
             expect { test_case.resolve(index_class) }.to raise_error do |error|
               expect(error).to be_a(ResolverError)
@@ -103,6 +105,17 @@ module Molinillo
           end
         end
       end
+    end
+
+    def ignore?(index_class)
+      if index_class == RandomSortIndex && name == 'resolves a conflict which requires non-trivial unwinding'
+
+        # This index occassionally finds orders that are *incredibly* slow to resolve,
+        # and greysteil hasn't found a way to speed it up yet.
+        return true
+      end
+
+      false
     end
 
     def self.save!(path, name, index, requirements, resolved)

--- a/spec/spec_helper/index.rb
+++ b/spec/spec_helper/index.rb
@@ -198,7 +198,7 @@ module Molinillo
     BundlerIndex,
     ReverseBundlerIndex,
     BundlerSingleAllNoPenaltyIndex,
-    # RandomSortIndex,
+    RandomSortIndex,
     CocoaPodsIndex,
     BerkshelfIndex,
   ].freeze

--- a/spec/state_spec.rb
+++ b/spec/state_spec.rb
@@ -13,7 +13,8 @@ module Molinillo
           'requirement',
           %w(possibility1 possibility),
           0,
-          {}
+          {},
+          []
         )
       end
 


### PR DESCRIPTION
Gets Molinillo to the point where it can resolve anything that's thrown at it. Includes the following fixes and speedups (which will be pulled out into separate PRs when they're ready):
- ~~Handling failures where an unwind of a previous conflict  is needed~~ (#72)
- ~~Speeding up resolution by filtering grandparent+ states~~ (#77)
- ~~Handling circular dependencies~~ (#78)
- Handling unwinds of a previous conflict *for the same dependency* is needed (this PR)

TODO:
- [x] Get specs passing in all known cases
  - [x] Testing locally should get no errors when running the `RandomSortIndex` specs 1000x
- [x] Improve performance while continuing to track all past conflicts (spec slow down is most noticeable on ReverseBundlerIndex, which is the place to start analysis...)
- [x] Clean up circular dependency handling (current special-casing feels grim)
- [x] Document approach in `ARCHITECTURE.md` where appropriate (speedup is undoubtedly going to require some hard thinking about how we loop through conflicts)
- [ ] Spec thorny cases (~~circular dependencies~~, multiple states for a single requirement, rewinding on previous conflicts)