### PR TITLE
Allow deps to change for the same possibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Allow the set of dependencies for a given possibility to change over time,
+  fixing a regression in 0.6.0.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 
 ## 0.6.0 (2017-07-27)

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -689,7 +689,8 @@ module Molinillo
       def attempt_to_filter_existing_spec(vertex)
         filtered_set = filtered_possibility_set(vertex)
         if !filtered_set.possibilities.empty? &&
-            (vertex.payload.dependencies == dependencies_for(possibility.latest_version))
+            (vertex.payload.dependencies == dependencies_for(possibility.latest_version) ||
+             vertex.payload.possibilities == possibility.possibilities)
           activated.set_payload(name, filtered_set)
           new_requirements = requirements.dup
           push_state_for_requirements(new_requirements, false)

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -688,9 +688,7 @@ module Molinillo
       # @return [void]
       def attempt_to_filter_existing_spec(vertex)
         filtered_set = filtered_possibility_set(vertex)
-        if !filtered_set.possibilities.empty? &&
-            (vertex.payload.dependencies == dependencies_for(possibility.latest_version) ||
-             vertex.payload.possibilities == possibility.possibilities)
+        if !filtered_set.possibilities.empty?
           activated.set_payload(name, filtered_set)
           new_requirements = requirements.dup
           push_state_for_requirements(new_requirements, false)
@@ -706,18 +704,7 @@ module Molinillo
       # @param [Object] existing vertex
       # @return [PossibilitySet] filtered possibility set
       def filtered_possibility_set(vertex)
-        # Note: we can't just look at the intersection of `vertex.payload.possibilities`
-        # and `possibility.possibilities`, because if one of our requirements contains
-        # a prerelease version the associated prerelease versions will only appear in
-        # one set (but may match all requirements)
-        filtered_old_values = vertex.payload.possibilities.select do |poss|
-          requirement_satisfied_by?(requirement, activated, poss)
-        end
-        filtered_new_values = possibility.possibilities.select do |poss|
-          vertex.requirements.uniq.all? { |req| requirement_satisfied_by?(req, activated, poss) }
-        end
-
-        PossibilitySet.new(vertex.payload.dependencies, filtered_old_values | filtered_new_values)
+        PossibilitySet.new(vertex.payload.dependencies, vertex.payload.possibilities & possibility.possibilities)
       end
 
       # @param [String] requirement_name the spec name to search for


### PR DESCRIPTION
Fixes https://travis-ci.org/bundler/bundler/jobs/258222644 (from https://github.com/bundler/bundler/pull/5902).

This is basically a short-circuit, so that when searching for different deps yields the same possibility, it's OK that dependencies can be added.