### PR TITLE
Ensure possibility sets only contain contiguous versions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,7 +18,7 @@ This stack-based approach is used because backtracking (also known as *unwinding
 2. The client calls `resolve` with an array of user-requested dependencies and an optional 'locking' `DependencyGraph`
 3. The `Resolver` creates a new `Resolution` with those four user-specified parameters and calls `resolve` on it
 4. The `Resolution` creates an `initial_state`, which takes the user-requested dependencies and puts them into a `DependencyState`
-  - In the process of creating the state, the `SpecificationProvider` is asked to sort the dependencies and return all the `possibilities` for the `initial_requirement` (taking into account whether the dependency is `locked`). These possibilities are then grouped into `PossibilitySet`s, with each set representing a group of versions for the dependency which share the same sub-dependency requirements
+  - In the process of creating the state, the `SpecificationProvider` is asked to sort the dependencies and return all the `possibilities` for the `initial_requirement` (taking into account whether the dependency is `locked`). These possibilities are then grouped into `PossibilitySet`s, with each set representing a group of versions for the dependency which share the same sub-dependency requirements and are contiguous
   - A `DependencyGraph` is created that has all of these requirements point to `root_vertices`
 5. The resolution process now enters its main loop, which continues as long as there is a current `state` to process, and the current state has requirements left to process
 6. `UI#indicate_progress` is called to allow the client to report progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 
 ##### Bug Fixes
 
-* None.  
+* Insist each PossibilitySet contains contiguous versions. Fixes a regression
+  where an older dependency version with identical sub-dependencies to the
+  latest version may be preferred over the second-latest version.
+  [Grey Baker](https://github.com/greysteil)
 
 
 ## 0.6.1 (2017-08-01)

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -791,24 +791,25 @@ module Molinillo
       end
 
       # Build an array of PossibilitySets, with each element representing a group of
-      # dependency versions that all have the same sub-dependency version constraints.
+      # dependency versions that all have the same sub-dependency version constraints
+      # and are contiguous.
       # @param [Array] an array of possibilities
       # @return [Array] an array of possibility sets
       def group_possibilities(possibilities)
         possibility_sets = []
-        possibility_sets_index = {}
+        current_possibility_set = nil
 
         possibilities.reverse_each do |possibility|
           dependencies = dependencies_for(possibility)
-          if index = possibility_sets_index[dependencies]
-            possibility_sets[index].possibilities.unshift(possibility)
+          if current_possibility_set && current_possibility_set.dependencies == dependencies
+            current_possibility_set.possibilities.unshift(possibility)
           else
-            possibility_sets << PossibilitySet.new(dependencies, [possibility])
-            possibility_sets_index[dependencies] = possibility_sets.count - 1
+            possibility_sets.unshift(PossibilitySet.new(dependencies, [possibility]))
+            current_possibility_set = possibility_sets.first
           end
         end
 
-        possibility_sets.reverse
+        possibility_sets
       end
 
       # Pushes a new {DependencyState}.


### PR DESCRIPTION
Insist each PossibilitySet contains contiguous versions. Fixes a potential regression where an older dependency version with identical sub-dependencies to the latest version may be preferred over the second-latest version.

(The above regression is pretty damn unlikely, but this makes the grouping logic theoretically robust, which is nice. And it's not going to slow anything down - non-contiguous groups would only be formed by pretty weird dependency maintainer behaviour.)

Test at https://github.com/CocoaPods/Resolver-Integration-Specs/pull/15.