### PR TITLE
Handle case of multiple previous primary unwinds to the same state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@
 
 ##### Bug Fixes
 
-* None.  
+* Handle the case where an unwind occurs to a requirement that directly caused
+  the current conflict but could also have been unwound to directly from
+  previous conflicts. In this case, filtering must not remove any possibilities
+  that could have avoided the previous conflicts (even if they would not avoid
+  the current one).  
+  [Grey Baker](https://github.com/greysteil)
 
 
 ## 0.6.2 (2017-08-25)

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -461,11 +461,15 @@ module Molinillo
       # @param [UnwindDetails] details of the conflict just unwound from
       # @return [void]
       def filter_possibilities_for_primary_unwind(unwind_details)
-        all_requirements = unwind_details.conflicting_requirements
+        unwinds_to_state = unused_unwind_options.select { |uw| uw.state_index == unwind_details.state_index }
+        unwinds_to_state << unwind_details
+        unwind_requirement_sets = unwinds_to_state.map(&:conflicting_requirements)
 
         state.possibilities.reject! do |possibility_set|
           possibility_set.possibilities.none? do |poss|
-            possibility_satisfies_requirements?(poss, all_requirements)
+            unwind_requirement_sets.any? do |requirements|
+              possibility_satisfies_requirements?(poss, requirements)
+            end
           end
         end
       end


### PR DESCRIPTION
If several previous conflicts would have unwound to the state we eventually unwind to, we shouldn't filter out the versions that would have fixed those previous conflicts.

- [x] Add spec
- [x] Add changelog entry