### PR TITLE
Prioritise explicitly requested gems in Bundler dependency sort order

### DIFF
--- a/spec/spec_helper/index.rb
+++ b/spec/spec_helper/index.rb
@@ -80,6 +80,7 @@ module Molinillo
         name = name_for(dependency)
         [
           activated.vertex_named(name).payload ? 0 : 1,
+          activated.vertex_named(name).root? ? 0 : 1,
           amount_constrained(dependency),
           conflicts[name] ? 0 : 1,
           activated.vertex_named(name).payload ? 0 : search_for(dependency).count,


### PR DESCRIPTION
Keeps Bundler index in-line with https://github.com/bundler/bundler/pull/6128. New spec will live in Bundler (since this is Bundler-specific).