### PR TITLE
Make `Vertex#requirements` array unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ##### Enhancements
 
-* None.  
+* Reduce memory usage during resolution by making the `Vertex#requirements`
+  array unique.  
+  [Grey Baker](https://github.com/greysteil)
+  [Jan Krutisch](https://github.com/halfbyte)
 
 ##### Bug Fixes
 

--- a/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/molinillo/dependency_graph/vertex.rb
@@ -33,7 +33,7 @@ module Molinillo
       # @return [Array<Object>] all of the requirements that required
       #   this vertex
       def requirements
-        incoming_edges.map(&:requirement) + explicit_requirements
+        (incoming_edges.map(&:requirement) + explicit_requirements).uniq
       end
 
       # @return [Array<Edge>] the edges of {#graph} that have `self` as their

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -218,7 +218,7 @@ module Molinillo
           next unless vertex.payload
 
           latest_version = vertex.payload.possibilities.reverse_each.find do |possibility|
-            vertex.requirements.uniq.all? { |req| requirement_satisfied_by?(req, activated, possibility) }
+            vertex.requirements.all? { |req| requirement_satisfied_by?(req, activated, possibility) }
           end
 
           activated.set_payload(vertex.name, latest_version)


### PR DESCRIPTION
Reduces memory usage during resolution. Part of the solution to https://github.com/bundler/bundler/issues/6114.

We're never interested in the size of a vertex's `requirements` array - only in its unique elements. As such, I don't see any reason not to`uniq` it at source.

Previously, we were `uniq`-ing the array in one of the places it was used, but not the other (`Molinillo::Resolver::Resolution#requirement_trees`). As a result, we were creating `Conflict` objects with `requirement_trees` arrays that contained duplicates. Doing so adversely affected memory usage during resolution.