### PR TITLE
Travis: use jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ rvm:
   - 2.3.3
   - 2.4.0
   - ruby-head
-  - jruby-9.0.4.0
+  - jruby-9.2.0.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html