### PR TITLE
Fix same spec in multi-sources search error

### DIFF
--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -708,7 +708,7 @@ module Molinillo
       # @param [Object] existing vertex
       # @return [PossibilitySet] filtered possibility set
       def filtered_possibility_set(vertex)
-        PossibilitySet.new(vertex.payload.dependencies, vertex.payload.possibilities & possibility.possibilities)
+        PossibilitySet.new(vertex.payload.dependencies, vertex.payload.possibilities.select { |e| possibility.possibilities.include? e })
       end
 
       # @param [String] requirement_name the spec name to search for

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -708,7 +708,9 @@ module Molinillo
       # @param [Object] existing vertex
       # @return [PossibilitySet] filtered possibility set
       def filtered_possibility_set(vertex)
-        PossibilitySet.new(vertex.payload.dependencies, vertex.payload.possibilities.select { |e| possibility.possibilities.include? e })
+        PossibilitySet.new(vertex.payload.dependencies, vertex.payload.possibilities.select do |e|
+          possibility.possibilities.include? e
+        end)
       end
 
       # @param [String] requirement_name the spec name to search for


### PR DESCRIPTION
When the same spec is present in multiple spec sources, the correct spec can sometimes not be found, for example:

~~~ruby
source 'https://github.com/dongdonggaui/Specs.git'
source 'https://github.com/CocoaPods/Specs.git'

target 'xx' do
  pod 'AFNetworking'
end
~~~

I expect what I want is from the first source, and indeed it comes from the second source.