### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/molinillo.gemspec
+++ b/molinillo.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb', '*.md', 'LICENSE']
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 1.8.7'
+
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Whilst it's a little odd to specify such a low required Ruby version, doing so will mean Dependabot doesn't try to update gems to versions that aren't compatible with that version.