### PR TITLE
Use rubygems 2.7.8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 
 install:
   - gem update --system 2.7.8
-  - gem install bundler -v ">= 1.10"
+  - gem install bundler -v "~> 1.17"
   - rake bootstrap
 
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   - LANG="en_US.UTF-8"
 
 install:
-  - gem update --system
+  - gem update --system 2.7.8
   - gem install bundler -v ">= 1.10"
   - rake bootstrap
 

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -183,7 +183,7 @@ Molinillo could not find compatible versions for possibility named "missing":
 Unable to satisfy the following requirements:
 
 - `json (>= 1.7.7)` required by `berkshelf (2.0.7)`
-- `json (<= 1.7.7, >= 1.4.4)` required by `chef (10.26)`
+- `json (>= 1.4.4, <= 1.7.7)` required by `chef (10.26)`
           EOS
           expect(conflict.message_with_trees(:version_for_spec => lambda(&:version))).to eq <<-EOS.strip
 Molinillo could not find compatible versions for possibility named "json":
@@ -194,7 +194,7 @@ Molinillo could not find compatible versions for possibility named "json":
 
     chef_app_error (>= 0) was resolved to 1.0.0, which depends on
       chef (~> 10.26) was resolved to 10.26, which depends on
-        json (<= 1.7.7, >= 1.4.4)
+        json (>= 1.4.4, <= 1.7.7)
           EOS
         end
       end


### PR DESCRIPTION
Fixes the build the lazy way. Longer term we should consider having a build matrix (but it's Monday morning and I'm swamped).

(Currently older rubies are failing because they're attempting to install Rubygems 3.0.2, which doesn't support them.)