### PR TITLE
Add YARD docstring annotations

### DIFF
--- a/lib/molinillo/compatibility.rb
+++ b/lib/molinillo/compatibility.rb
@@ -8,7 +8,7 @@ module Molinillo
     if [].respond_to?(:flat_map)
       # Flat map
       # @param [Enumerable] enum an enumerable object
-      # @block the block to flat-map with
+      # @param blk the block to flat-map with
       # @return The enum, flat-mapped
       def flat_map(enum, &blk)
         enum.flat_map(&blk)
@@ -16,7 +16,7 @@ module Molinillo
     else
       # Flat map
       # @param [Enumerable] enum an enumerable object
-      # @block the block to flat-map with
+      # @param blk the block to flat-map with
       # @return The enum, flat-mapped
       def flat_map(enum, &blk)
         enum.map(&blk).flatten(1)

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -124,6 +124,7 @@ module Molinillo
       dot.join("\n")
     end
 
+    # @param [DependencyGraph] other
     # @return [Boolean] whether the two dependency graphs are equal, determined
     #   by a recursive traversal of each {#root_vertices} and its
     #   {Vertex#successors}

--- a/lib/molinillo/dependency_graph/tag.rb
+++ b/lib/molinillo/dependency_graph/tag.rb
@@ -14,11 +14,11 @@ module Molinillo
       end
 
       # (see Action#up)
-      def up(_graph)
+      def up(graph)
       end
 
       # (see Action#down)
-      def down(_graph)
+      def down(graph)
       end
 
       # @!group Tag

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -361,7 +361,7 @@ module Molinillo
         current_detail
       end
 
-      # @param [Array<Object>] array of requirements that combine to create a conflict
+      # @param [Array<Object>] binding_requirements array of requirements that combine to create a conflict
       # @return [Array<UnwindDetails>] array of UnwindDetails that have a chance
       #    of resolving the passed requirements
       def unwind_options_for_requirements(binding_requirements)
@@ -429,7 +429,7 @@ module Molinillo
       end
 
       # @param [DependencyState] state
-      # @param [Array] array of requirements
+      # @param [Array] binding_requirements array of requirements
       # @return [Boolean] whether or not the given state has any possibilities
       #    that could satisfy the given requirements
       def conflict_fixing_possibilities?(state, binding_requirements)
@@ -444,7 +444,8 @@ module Molinillo
 
       # Filter's a state's possibilities to remove any that would not fix the
       # conflict we've just rewound from
-      # @param [UnwindDetails] details of the conflict just unwound from
+      # @param [UnwindDetails] unwind_details details of the conflict just
+      #   unwound from
       # @return [void]
       def filter_possibilities_after_unwind(unwind_details)
         return unless state && !state.possibilities.empty?
@@ -458,7 +459,7 @@ module Molinillo
 
       # Filter's a state's possibilities to remove any that would not satisfy
       # the requirements in the conflict we've just rewound from
-      # @param [UnwindDetails] details of the conflict just unwound from
+      # @param [UnwindDetails] unwind_details details of the conflict just unwound from
       # @return [void]
       def filter_possibilities_for_primary_unwind(unwind_details)
         unwinds_to_state = unused_unwind_options.select { |uw| uw.state_index == unwind_details.state_index }
@@ -491,7 +492,7 @@ module Molinillo
 
       # Filter's a state's possibilities to remove any that would (eventually)
       # create a requirement in the conflict we've just rewound from
-      # @param [UnwindDetails] details of the conflict just unwound from
+      # @param [UnwindDetails] unwind_details details of the conflict just unwound from
       # @return [void]
       def filter_possibilities_for_parent_unwind(unwind_details)
         unwinds_to_state = unused_unwind_options.select { |uw| uw.state_index == unwind_details.state_index }
@@ -558,8 +559,8 @@ module Molinillo
       end
 
       # @param [Object] requirement we wish to check
-      # @param [Array] array of requirements
-      # @param [Array] array of possibilities the requirements will be used to filter
+      # @param [Array] possible_binding_requirements array of requirements
+      # @param [Array] possibilities array of possibilities the requirements will be used to filter
       # @return [Boolean] whether or not the given requirement is required to filter
       #    out all elements of the array of possibilities.
       def binding_requirement_in_set?(requirement, possible_binding_requirements, possibilities)
@@ -568,6 +569,7 @@ module Molinillo
         end
       end
 
+      # @param [Object] requirement
       # @return [Object] the requirement that led to `requirement` being added
       #   to the list of requirements.
       def parent_of(requirement)
@@ -577,6 +579,7 @@ module Molinillo
         parent_state.requirement
       end
 
+      # @param [String] name
       # @return [Object] the requirement that led to a version of a possibility
       #   with the given name being activated.
       def requirement_for_existing_name(name)
@@ -585,6 +588,7 @@ module Molinillo
         states.find { |s| s.name == name }.requirement
       end
 
+      # @param [Object] requirement
       # @return [ResolutionState] the state whose `requirement` is the given
       #   `requirement`.
       def find_state_for(requirement)
@@ -592,6 +596,7 @@ module Molinillo
         states.find { |i| requirement == i.requirement }
       end
 
+      # @param [Object] underlying_error
       # @return [Conflict] a {Conflict} that reflects the failure to activate
       #   the {#possibility} in conjunction with the current {#state}
       def create_conflict(underlying_error = nil)
@@ -628,6 +633,7 @@ module Molinillo
         vertex.requirements.map { |r| requirement_tree_for(r) }
       end
 
+      # @param [Object] requirement
       # @return [Array<Object>] the list of requirements that led to
       #   `requirement` being required.
       def requirement_tree_for(requirement)
@@ -705,7 +711,7 @@ module Molinillo
 
       # Generates a filtered version of the existing vertex's `PossibilitySet` using the
       # current state's `requirement`
-      # @param [Object] existing vertex
+      # @param [Object] vertex existing vertex
       # @return [PossibilitySet] filtered possibility set
       def filtered_possibility_set(vertex)
         PossibilitySet.new(vertex.payload.dependencies, vertex.payload.possibilities & possibility.possibilities)
@@ -730,7 +736,7 @@ module Molinillo
       end
 
       # Requires the dependencies that the recently activated spec has
-      # @param [Object] activated_possibility the PossibilitySet that has just been
+      # @param [Object] possibility_set the PossibilitySet that has just been
       #   activated
       # @return [void]
       def require_nested_dependencies_for(possibility_set)
@@ -749,6 +755,8 @@ module Molinillo
       # Pushes a new {DependencyState} that encapsulates both existing and new
       # requirements
       # @param [Array] new_requirements
+      # @param [Boolean] requires_sort
+      # @param [Object] new_activated
       # @return [void]
       def push_state_for_requirements(new_requirements, requires_sort = true, new_activated = activated)
         new_requirements = sort_dependencies(new_requirements.uniq, new_activated, conflicts) if requires_sort
@@ -767,7 +775,8 @@ module Molinillo
 
       # Checks a proposed requirement with any existing locked requirement
       # before generating an array of possibilities for it.
-      # @param [Object] the proposed requirement
+      # @param [Object] requirement the proposed requirement
+      # @param [Object] activated
       # @return [Array] possibilities
       def possibilities_for_requirement(requirement, activated = self.activated)
         return [] unless requirement
@@ -778,7 +787,8 @@ module Molinillo
         group_possibilities(search_for(requirement))
       end
 
-      # @param [Object] the proposed requirement
+      # @param [Object] requirement the proposed requirement
+      # @param [Object] activated
       # @return [Array] possibility set containing only the locked requirement, if any
       def locked_requirement_possibility_set(requirement, activated = self.activated)
         all_possibilities = search_for(requirement)
@@ -797,8 +807,8 @@ module Molinillo
       # Build an array of PossibilitySets, with each element representing a group of
       # dependency versions that all have the same sub-dependency version constraints
       # and are contiguous.
-      # @param [Array] an array of possibilities
-      # @return [Array] an array of possibility sets
+      # @param [Array] possibilities an array of possibilities
+      # @return [Array<PossibilitySet>] an array of possibility sets
       def group_possibilities(possibilities)
         possibility_sets = []
         current_possibility_set = nil


### PR DESCRIPTION
This PR adds a few YARD annotations to reduce the amount of warnings output when generating documentation (and also, to fix some references).

This does not take care of _all_ the warnings output, but it's an improvement.

## Screenshot

This screenshot shows how `Tag` now works, again, because it has the same names of arguments as `Action` (the docstrings of which are used by `(see ...)` reference).

![image](https://user-images.githubusercontent.com/211/55257838-6d442a80-5261-11e9-875d-4d285b468220.png)
