### PR TITLE
CI: Update patch versions of Ruby, add Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo:  false
 
 branches:
   only:
@@ -13,8 +12,9 @@ addons:
 rvm:
   - 2.0.0
   - 2.3.8
-  - 2.4.6
-  - 2.6.3
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
   - 2.7.1
   - ruby-head
   - jruby-9.2.11.1


### PR DESCRIPTION
This PR updates the CI matrix.

  - Updates Ruby patch versions
  - Adds Ruby 2.5 to the matrix.
  - Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Still green! 🟢 