### PR TITLE
Include full path in CircularDependencyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Enhancements
 
-* None.  
+* Circular dependency errors include the full (shortest) path between the
+  circularly-dependent vertices.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,4 +97,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -191,7 +191,7 @@ module Molinillo
     # @return [Edge] the added edge
     def add_edge(origin, destination, requirement)
       if destination.path_to?(origin)
-        raise CircularDependencyError.new([origin, destination])
+        raise CircularDependencyError.new(path(destination, origin))
       end
       add_edge_no_circular(origin, destination, requirement)
     end
@@ -219,6 +219,38 @@ module Molinillo
     # @return (see #add_edge)
     def add_edge_no_circular(origin, destination, requirement)
       log.add_edge_no_circular(self, origin.name, destination.name, requirement)
+    end
+
+    # Returns the path between two vertices
+    # @raise [ArgumentError] if there is no path between the vertices
+    # @param [Vertex] from
+    # @param [Vertex] to
+    # @return [Array<Vertex>] the shortest path from `from` to `to`
+    def path(from, to)
+      distances = Hash.new(vertices.size + 1)
+      distances[from.name] = 0
+      predecessors = {}
+      each do |vertex|
+        vertex.successors.each do |successor|
+          if distances[successor.name] > distances[vertex.name] + 1
+            distances[successor.name] = distances[vertex.name] + 1
+            predecessors[successor] = vertex
+          end
+        end
+      end
+
+      path = [to]
+      while before = predecessors[to]
+        path << before
+        to = before
+        break if to == from
+      end
+
+      unless path.last.equal?(from)
+        raise ArgumentError, "There is no path from #{from.name} to #{to.name}"
+      end
+
+      path.reverse
     end
   end
 end


### PR DESCRIPTION
This will help make resolving those circular dependency errors easier for end users.