### PR TITLE
Prefer `require_relative` to `require` for internal requires

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     docile (1.1.5)
-    ffi (1.11.0)
+    ffi (1.11.1)
     inch (0.8.0)
       pry
       sparkr (>= 0.2.0)

--- a/lib/molinillo.rb
+++ b/lib/molinillo.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'molinillo/compatibility'
-require 'molinillo/gem_metadata'
-require 'molinillo/errors'
-require 'molinillo/resolver'
-require 'molinillo/modules/ui'
-require 'molinillo/modules/specification_provider'
+require_relative 'molinillo/compatibility'
+require_relative 'molinillo/gem_metadata'
+require_relative 'molinillo/errors'
+require_relative 'molinillo/resolver'
+require_relative 'molinillo/modules/ui'
+require_relative 'molinillo/modules/specification_provider'
 
 # Molinillo is a generic dependency resolution algorithm.
 module Molinillo

--- a/lib/molinillo/dependency_graph.rb
+++ b/lib/molinillo/dependency_graph.rb
@@ -3,8 +3,8 @@
 require 'set'
 require 'tsort'
 
-require 'molinillo/dependency_graph/log'
-require 'molinillo/dependency_graph/vertex'
+require_relative 'dependency_graph/log'
+require_relative 'dependency_graph/vertex'
 
 module Molinillo
   # A directed acyclic graph that is tuned to hold named dependencies

--- a/lib/molinillo/dependency_graph/add_edge_no_circular.rb
+++ b/lib/molinillo/dependency_graph/add_edge_no_circular.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph/action'
+require_relative 'action'
 module Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/molinillo/dependency_graph/add_vertex.rb
+++ b/lib/molinillo/dependency_graph/add_vertex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph/action'
+require_relative 'action'
 module Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/molinillo/dependency_graph/delete_edge.rb
+++ b/lib/molinillo/dependency_graph/delete_edge.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph/action'
+require_relative 'action'
 module Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/molinillo/dependency_graph/detach_vertex_named.rb
+++ b/lib/molinillo/dependency_graph/detach_vertex_named.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph/action'
+require_relative 'action'
 module Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/molinillo/dependency_graph/log.rb
+++ b/lib/molinillo/dependency_graph/log.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph/add_edge_no_circular'
-require 'molinillo/dependency_graph/add_vertex'
-require 'molinillo/dependency_graph/delete_edge'
-require 'molinillo/dependency_graph/detach_vertex_named'
-require 'molinillo/dependency_graph/set_payload'
-require 'molinillo/dependency_graph/tag'
+require_relative 'add_edge_no_circular'
+require_relative 'add_vertex'
+require_relative 'delete_edge'
+require_relative 'detach_vertex_named'
+require_relative 'set_payload'
+require_relative 'tag'
 
 module Molinillo
   class DependencyGraph

--- a/lib/molinillo/dependency_graph/set_payload.rb
+++ b/lib/molinillo/dependency_graph/set_payload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph/action'
+require_relative 'action'
 module Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/molinillo/dependency_graph/tag.rb
+++ b/lib/molinillo/dependency_graph/tag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph/action'
+require_relative 'action'
 module Molinillo
   class DependencyGraph
     # @!visibility private

--- a/lib/molinillo/errors.rb
+++ b/lib/molinillo/errors.rb
@@ -80,7 +80,7 @@ module Molinillo
       @specification_provider = specification_provider
     end
 
-    require 'molinillo/delegates/specification_provider'
+    require_relative 'delegates/specification_provider'
     include Delegates::SpecificationProvider
 
     # @return [String] An error message that includes requirement trees,

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -238,11 +238,11 @@ module Molinillo
         debug { 'Activated: ' + Hash[activated.vertices.select { |_n, v| v.payload }].keys.join(', ') } if state
       end
 
-      require 'molinillo/state'
-      require 'molinillo/modules/specification_provider'
+      require_relative 'state'
+      require_relative 'modules/specification_provider'
 
-      require 'molinillo/delegates/resolution_state'
-      require 'molinillo/delegates/specification_provider'
+      require_relative 'delegates/resolution_state'
+      require_relative 'delegates/specification_provider'
 
       include Molinillo::Delegates::ResolutionState
       include Molinillo::Delegates::SpecificationProvider

--- a/lib/molinillo/resolver.rb
+++ b/lib/molinillo/resolver.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'molinillo/dependency_graph'
+require_relative 'dependency_graph'
 
 module Molinillo
   # This class encapsulates a dependency resolver.
@@ -9,7 +9,7 @@ module Molinillo
   #
   #
   class Resolver
-    require 'molinillo/resolution'
+    require_relative 'resolution'
 
     # @return [SpecificationProvider] the specification provider used
     #   in the resolution process

--- a/molinillo.gemspec
+++ b/molinillo.gemspec
@@ -1,9 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'molinillo/gem_metadata'
+require_relative 'lib/molinillo/gem_metadata'
 
 Gem::Specification.new do |spec|
   spec.name          = 'molinillo'


### PR DESCRIPTION
As I explained in #127, now that molinillo supports MRI >= 2.0 only, I'd like to use `require_relative` for internal requires.