### PR TITLE
Simplify 1.8.7 compatibility code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
   - 2.4.6
   - 2.6.3
   - ruby-head
-  - jruby-9.2.0.0
+  - jruby-9.2.8.0
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   - LANG="en_US.UTF-8"
 
 install:
-  - gem update --system 2.7.8
+  - gem update --system 2.7.10
   - gem install bundler -v "~> 1.17"
   - rake bootstrap
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -668,9 +668,8 @@ module Molinillo
           attempt_to_filter_existing_spec(existing_vertex)
         else
           latest = possibility.latest_version
-          # use reject!(!satisfied) for 1.8.7 compatibility
-          possibility.possibilities.reject! do |possibility|
-            !requirement_satisfied_by?(requirement, activated, possibility)
+          possibility.possibilities.select! do |possibility|
+            requirement_satisfied_by?(requirement, activated, possibility)
           end
           if possibility.latest_version.nil?
             # ensure there's a possibility for better error messages


### PR DESCRIPTION
At 1.8.7 times, `Array.select!` didn't exist. Now it does.