### PR TITLE
Fix `vertex.inspect`

### DIFF
--- a/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/molinillo/dependency_graph/vertex.rb
@@ -98,7 +98,7 @@ module Molinillo
 
       # @return [String] a string suitable for debugging
       def inspect
-        "#{self.class}:#{name}(#{payload.inspect})"
+        "#{self.class}:#{name}(#{payload})"
       end
 
       # @return [Boolean] whether the two vertices are equal, determined


### PR DESCRIPTION
This fails in bundler when doing `dependency_graph.inspect` as ruby and rubygems dependencies are named "Ruby\0" and "RubyGems\0" which causes a `ArgumentError` with message `string contains null byte`. There appears to be some bug in how inspect is called, as calling inspect on a string with a null byte works without issue.