### PR TITLE
Use `Array#-` in unwind logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Use `Array#-` in unwind logic, since it performs better than `Array#&`, so it
+  speeds up resolution.  
+  [Lukas Oberhuber](https://github.com/lukaso)
 
 ##### Bug Fixes
 

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -329,11 +329,11 @@ module Molinillo
 
         # Look for past conflicts that could be unwound to affect the
         # requirement tree for the current conflict
+        all_reqs = last_detail_for_current_unwind.all_requirements
+        all_reqs_size = all_reqs.size
         relevant_unused_unwinds = unused_unwind_options.select do |alternative|
-          intersecting_requirements =
-            last_detail_for_current_unwind.all_requirements &
-            alternative.requirements_unwound_to_instead
-          next if intersecting_requirements.empty?
+          diff_reqs = all_reqs - alternative.requirements_unwound_to_instead
+          next if diff_reqs.size == all_reqs_size
           # Find the highest index unwind whilst looping through
           current_detail = alternative if alternative > current_detail
           alternative
@@ -344,8 +344,12 @@ module Molinillo
         state.unused_unwind_options += unwind_details.reject { |detail| detail.state_index == -1 }
 
         # Update the requirements_unwound_to_instead on any relevant unused unwinds
-        relevant_unused_unwinds.each { |d| d.requirements_unwound_to_instead << current_detail.state_requirement }
-        unwind_details.each { |d| d.requirements_unwound_to_instead << current_detail.state_requirement }
+        relevant_unused_unwinds.each do |d|
+          (d.requirements_unwound_to_instead << current_detail.state_requirement).uniq!
+        end
+        unwind_details.each do |d|
+          (d.requirements_unwound_to_instead << current_detail.state_requirement).uniq!
+        end
 
         current_detail
       end


### PR DESCRIPTION
This is a hot code path during resolution and `Array#-` performs much better than `Array#&`.

With the following sample `Gemfile`:

```ruby
source 'https://rubygems.org'

gem "actionmailer"
gem "mongoid", ">= 0.10.2"
```

It reduces `bundle lock` time from 9.5s to 2.8s on my machine.

All credit to @lukaso for this improvement!