### PR TITLE
Use `printable_requirement` proc to print requirements

### DIFF
--- a/lib/molinillo/errors.rb
+++ b/lib/molinillo/errors.rb
@@ -121,7 +121,7 @@ module Molinillo
           t = ''.dup
           depth = 2
           tree.each do |req|
-            t << '  ' * depth << req.to_s
+            t << '  ' * depth << printable_requirement.call(req)
             unless tree.last == req
               if spec = conflict.activated_by_name[name_for(req)]
                 t << %( was resolved to #{version_for_spec.call(spec)}, which)


### PR DESCRIPTION
Molinillo provides this proc to customize how requirements are printed, but was not respecting it.