### PR TITLE
Allow customization of dependency comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   speeds up resolution.  
   [Lukas Oberhuber](https://github.com/lukaso)
 
+* Allow specification provider to customize how dependencies are compared when
+  grouping specifications with the same dependencies.  
+  [David Rodríguez](https://github.com/deivid-rodriguez)
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/molinillo/delegates/specification_provider.rb
+++ b/lib/molinillo/delegates/specification_provider.rb
@@ -26,6 +26,13 @@ module Molinillo
         end
       end
 
+      # (see Molinillo::SpecificationProvider#dependencies_equal?)
+      def dependencies_equal?(dependencies, other_dependencies)
+        with_no_such_dependency_error_handling do
+          specification_provider.dependencies_equal?(dependencies, other_dependencies)
+        end
+      end
+
       # (see Molinillo::SpecificationProvider#name_for)
       def name_for(dependency)
         with_no_such_dependency_error_handling do

--- a/lib/molinillo/modules/specification_provider.rb
+++ b/lib/molinillo/modules/specification_provider.rb
@@ -45,6 +45,17 @@ module Molinillo
       true
     end
 
+    # Determines whether two arrays of dependencies are equal, and thus can be
+    # grouped.
+    #
+    # @param [Array<Object>] dependencies
+    # @param [Array<Object>] other_dependencies
+    # @return [Boolean] whether `dependencies` and `other_dependencies` should
+    #   be considered equal.
+    def dependencies_equal?(dependencies, other_dependencies)
+      dependencies == other_dependencies
+    end
+
     # Returns the name for the given `dependency`.
     # @note This method should be 'pure', i.e. the return value should depend
     #   only on the `dependency` parameter.

--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -807,7 +807,7 @@ module Molinillo
 
         possibilities.reverse_each do |possibility|
           dependencies = dependencies_for(possibility)
-          if current_possibility_set && current_possibility_set.dependencies == dependencies
+          if current_possibility_set && dependencies_equal?(current_possibility_set.dependencies, dependencies)
             current_possibility_set.possibilities.unshift(possibility)
           else
             possibility_sets.unshift(PossibilitySet.new(dependencies, [possibility]))


### PR DESCRIPTION
Bundler uses `DepProxy` instances as dependencies which are made of an underlying actual dependency and a platform.

However, during resolution only the actual dependency is relevant regarding dependency grouping, so by customizing this method like this

```ruby
dependencies.map(&:dep) == other_dependencies.map(&:dep)
```

we get a more efficient resolution since all spec groups with the same dependencies are properly grouped together.

For example, the Gemfile in [this ticket](https://github.com/rubygems/rubygems/issues/3788) is now resolved very fast.