### PR TITLE
Replace "iff" with "whether" and "if and only if"

### DIFF
--- a/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/molinillo/dependency_graph/vertex.rb
@@ -128,7 +128,7 @@ module Molinillo
 
       # Is there a path from `self` to `other` following edges in the
       # dependency graph?
-      # @return true iff there is a path following edges within this {#graph}
+      # @return whether there is a path following edges within this {#graph}
       def path_to?(other)
         _path_to?(other)
       end
@@ -147,7 +147,7 @@ module Molinillo
 
       # Is there a path from `other` to `self` following edges in the
       # dependency graph?
-      # @return true iff there is a path following edges within this {#graph}
+      # @return whether there is a path following edges within this {#graph}
       def ancestor?(other)
         other.path_to?(self)
       end

--- a/lib/molinillo/errors.rb
+++ b/lib/molinillo/errors.rb
@@ -34,7 +34,7 @@ module Molinillo
 
   # An error caused by attempting to fulfil a dependency that was circular
   #
-  # @note This exception will be thrown iff a {Vertex} is added to a
+  # @note This exception will be thrown if and only if a {Vertex} is added to a
   #   {DependencyGraph} that has a {DependencyGraph::Vertex#path_to?} an
   #   existing {DependencyGraph::Vertex}
   class CircularDependencyError < ResolverError


### PR DESCRIPTION
iff means if and only if, but readers without that knowledge might
assume this to be a spelling mistake. To me, this seems like
exclusionary language that is unnecessary. Simply using "if and only if"
or "whether" should suffice.

See https://github.com/ruby/ruby/pull/4035, https://github.com/rubygems/rubygems/pull/4311

I submitted a patch to Ruby to reword this potentially confusing wording. It turns out Rubygems vendors this gem and `iff` exists in this codebase as well. I propose it be changed here as well.