### PR TITLE
rm duplicate activated.tag(s)

### DIFF
--- a/lib/molinillo/resolution.rb
+++ b/lib/molinillo/resolution.rb
@@ -175,7 +175,6 @@ module Molinillo
             state.pop_possibility_state.tap do |s|
               if s
                 states.push(s)
-                activated.tag(s)
               end
             end
           end


### PR DESCRIPTION
cause new PossibilityState already push the state.
```
state.activated.tag(state)
```