### PR TITLE
Fix CI with latest ruby-head

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install things
         run: |
-          gem update --system 3.1.3
+          gem update --system 3.2.3
           gem install rake
           gem install bundler -v "~> 2.2"
           rake bootstrap


### PR DESCRIPTION
Rubygems 3.1.3 is not supported by latest version of Ruby.