### PR TITLE
Allow fully customizing molinillo's error building

### DIFF
--- a/lib/molinillo/errors.rb
+++ b/lib/molinillo/errors.rb
@@ -107,36 +107,42 @@ module Molinillo
         end
       end
 
-      conflicts.sort.reduce(''.dup) do |o, (name, conflict)|
-        o << "\n" << incompatible_version_message_for_conflict.call(name, conflict) << "\n"
-        if conflict.locked_requirement
-          o << %(  In snapshot (#{name_for_locking_dependency_source}):\n)
-          o << %(    #{printable_requirement.call(conflict.locked_requirement)}\n)
-          o << %(\n)
-        end
-        o << %(  In #{name_for_explicit_dependency_source}:\n)
-        trees = reduce_trees.call(conflict.requirement_trees)
-
-        o << trees.map do |tree|
-          t = ''.dup
-          depth = 2
-          tree.each do |req|
-            t << '  ' * depth << printable_requirement.call(req)
-            unless tree.last == req
-              if spec = conflict.activated_by_name[name_for(req)]
-                t << %( was resolved to #{version_for_spec.call(spec)}, which)
-              end
-              t << %( depends on)
-            end
-            t << %(\n)
-            depth += 1
+      full_message_for_conflict = opts.delete(:full_message_for_conflict) do
+        proc do |name, conflict|
+          o = "\n".dup << incompatible_version_message_for_conflict.call(name, conflict) << "\n"
+          if conflict.locked_requirement
+            o << %(  In snapshot (#{name_for_locking_dependency_source}):\n)
+            o << %(    #{printable_requirement.call(conflict.locked_requirement)}\n)
+            o << %(\n)
           end
-          t
-        end.join("\n")
+          o << %(  In #{name_for_explicit_dependency_source}:\n)
+          trees = reduce_trees.call(conflict.requirement_trees)
 
-        additional_message_for_conflict.call(o, name, conflict)
+          o << trees.map do |tree|
+            t = ''.dup
+            depth = 2
+            tree.each do |req|
+              t << '  ' * depth << printable_requirement.call(req)
+              unless tree.last == req
+                if spec = conflict.activated_by_name[name_for(req)]
+                  t << %( was resolved to #{version_for_spec.call(spec)}, which)
+                end
+                t << %( depends on)
+              end
+              t << %(\n)
+              depth += 1
+            end
+            t
+          end.join("\n")
 
-        o
+          additional_message_for_conflict.call(o, name, conflict)
+
+          o
+        end
+      end
+
+      conflicts.sort.reduce(''.dup) do |o, (name, conflict)|
+        o << full_message_for_conflict.call(name, conflict)
       end.strip
     end
   end


### PR DESCRIPTION
Currently bundler needs to passed 7 different procs as options, and the logic is split between those procs and molinillo's internals which makes it really hard to follow.

In addition to that, the above is not even enough for our needs. We have some "metadata dependencies" (the running Ruby and RubyGems version), which are not set in the dependency manifest (Gemfile), so we need to customize the message so that it does not read "In Gemfile:". However, that part is not currently customizable.

This commit adds a new proc that allows customizing building the full error message.